### PR TITLE
feat(micrometer):  add prometheus metrics instrumentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
 
+    <!-- micrometer for application metrics instrumentation -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+
     <!-- data redis for caching and session management -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/ebikes/iam/IAMApplication.java
+++ b/src/main/java/com/ebikes/iam/IAMApplication.java
@@ -1,9 +1,10 @@
 package com.ebikes.iam;
 
-import lombok.extern.log4j.Log4j2;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import lombok.extern.log4j.Log4j2;
 
 @SpringBootApplication
 @EnableScheduling

--- a/src/main/java/com/ebikes/iam/configurations/AuditingConfiguration.java
+++ b/src/main/java/com/ebikes/iam/configurations/AuditingConfiguration.java
@@ -1,14 +1,15 @@
 package com.ebikes.iam.configurations;
 
-import com.ebikes.iam.support.context.ExecutionContext;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-import java.time.OffsetDateTime;
-import java.util.Optional;
+import com.ebikes.iam.support.context.ExecutionContext;
 
 @Configuration
 @EnableJpaAuditing(dateTimeProviderRef = "offsetDateTimeProvider")

--- a/src/main/java/com/ebikes/iam/configurations/EventConsumerConfiguration.java
+++ b/src/main/java/com/ebikes/iam/configurations/EventConsumerConfiguration.java
@@ -1,12 +1,14 @@
 package com.ebikes.iam.configurations;
 
-import com.ebikes.iam.listeners.IncomingEventListener;
-import lombok.RequiredArgsConstructor;
+import java.util.function.Consumer;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
 
-import java.util.function.Consumer;
+import com.ebikes.iam.listeners.IncomingEventListener;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor

--- a/src/main/java/com/ebikes/iam/configurations/KeycloakConfiguration.java
+++ b/src/main/java/com/ebikes/iam/configurations/KeycloakConfiguration.java
@@ -1,14 +1,12 @@
 package com.ebikes.iam.configurations;
 
-import com.ebikes.iam.configurations.properties.KeycloakProperties;
-import com.ebikes.iam.constants.ApplicationConstants;
-import com.ebikes.iam.enums.ResponseCode;
-import com.ebikes.iam.exceptions.ExternalServiceException;
-import com.ebikes.iam.exceptions.RateLimitException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
 import jakarta.ws.rs.client.ClientResponseContext;
 import jakarta.ws.rs.client.ClientResponseFilter;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.keycloak.OAuth2Constants;
@@ -16,12 +14,17 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import com.ebikes.iam.configurations.properties.KeycloakProperties;
+import com.ebikes.iam.constants.ApplicationConstants;
+import com.ebikes.iam.enums.ResponseCode;
+import com.ebikes.iam.exceptions.ExternalServiceException;
+import com.ebikes.iam.exceptions.RateLimitException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
-
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
 
 @Configuration
 @RequiredArgsConstructor

--- a/src/main/java/com/ebikes/iam/configurations/RedisConfiguration.java
+++ b/src/main/java/com/ebikes/iam/configurations/RedisConfiguration.java
@@ -1,12 +1,13 @@
 package com.ebikes.iam.configurations;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Configuration
 @Slf4j

--- a/src/main/java/com/ebikes/iam/configurations/SecurityConfiguration.java
+++ b/src/main/java/com/ebikes/iam/configurations/SecurityConfiguration.java
@@ -1,10 +1,13 @@
 package com.ebikes.iam.configurations;
 
-import com.ebikes.iam.configurations.properties.SecurityProperties;
-import com.ebikes.iam.dtos.responses.api.ErrorResponse;
-import com.ebikes.iam.enums.ResponseCode;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
 import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,15 +28,14 @@ import org.springframework.security.oauth2.server.resource.BearerTokenError;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
-import tools.jackson.databind.ObjectMapper;
 
-import java.time.Instant;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import com.ebikes.iam.configurations.properties.SecurityProperties;
+import com.ebikes.iam.dtos.responses.api.ErrorResponse;
+import com.ebikes.iam.enums.ResponseCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import tools.jackson.databind.ObjectMapper;
 
 @Configuration
 @EnableMethodSecurity

--- a/src/main/java/com/ebikes/iam/configurations/filters/ContextFilter.java
+++ b/src/main/java/com/ebikes/iam/configurations/filters/ContextFilter.java
@@ -1,16 +1,17 @@
 package com.ebikes.iam.configurations.filters;
 
-import com.ebikes.iam.constants.ApplicationConstants;
-import com.ebikes.iam.constants.MDCKeys;
-import com.ebikes.iam.support.context.ExecutionContext;
-import com.ebikes.iam.support.references.ReferenceGenerator;
-import com.ebikes.iam.support.web.IpAddressUtilities;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
+
 import org.slf4j.MDC;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -19,12 +20,14 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.ebikes.iam.constants.ApplicationConstants;
+import com.ebikes.iam.constants.MDCKeys;
+import com.ebikes.iam.support.context.ExecutionContext;
+import com.ebikes.iam.support.references.ReferenceGenerator;
+import com.ebikes.iam.support.web.IpAddressUtilities;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j

--- a/src/main/java/com/ebikes/iam/configurations/properties/ContactProperties.java
+++ b/src/main/java/com/ebikes/iam/configurations/properties/ContactProperties.java
@@ -1,8 +1,9 @@
 package com.ebikes.iam.configurations.properties;
 
-import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+
+import lombok.Data;
 
 @Component
 @ConfigurationProperties(prefix = "contact")

--- a/src/main/java/com/ebikes/iam/configurations/properties/KeycloakProperties.java
+++ b/src/main/java/com/ebikes/iam/configurations/properties/KeycloakProperties.java
@@ -1,12 +1,14 @@
 package com.ebikes.iam.configurations.properties;
 
+import java.util.Map;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import lombok.Data;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
+import lombok.Data;
 
 @ConfigurationProperties(prefix = "keycloak")
 @Component

--- a/src/main/java/com/ebikes/iam/configurations/properties/NotificationProperties.java
+++ b/src/main/java/com/ebikes/iam/configurations/properties/NotificationProperties.java
@@ -1,9 +1,10 @@
 package com.ebikes.iam.configurations.properties;
 
-import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
+
+import lombok.Data;
 
 @ConfigurationProperties(prefix = "notifications")
 @Component

--- a/src/main/java/com/ebikes/iam/configurations/properties/RateLimitProperties.java
+++ b/src/main/java/com/ebikes/iam/configurations/properties/RateLimitProperties.java
@@ -1,9 +1,10 @@
 package com.ebikes.iam.configurations.properties;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import lombok.Setter;
 
 @Configuration
 @ConfigurationProperties(prefix = "rate-limit")

--- a/src/main/java/com/ebikes/iam/configurations/properties/SecurityProperties.java
+++ b/src/main/java/com/ebikes/iam/configurations/properties/SecurityProperties.java
@@ -1,11 +1,12 @@
 package com.ebikes.iam.configurations.properties;
 
-import lombok.Data;
+import java.util.List;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.annotation.Validated;
 
-import java.util.List;
+import lombok.Data;
 
 @Configuration
 @ConfigurationProperties(prefix = "security")

--- a/src/main/java/com/ebikes/iam/configurations/properties/TokenProperties.java
+++ b/src/main/java/com/ebikes/iam/configurations/properties/TokenProperties.java
@@ -1,8 +1,9 @@
 package com.ebikes.iam.configurations.properties;
 
-import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+
+import lombok.Data;
 
 @Component
 @ConfigurationProperties(prefix = "token")

--- a/src/main/java/com/ebikes/iam/configurations/properties/WebClientProperties.java
+++ b/src/main/java/com/ebikes/iam/configurations/properties/WebClientProperties.java
@@ -1,9 +1,10 @@
 package com.ebikes.iam.configurations.properties;
 
-import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
+
+import lombok.Data;
 
 @ConfigurationProperties(prefix = "web-client")
 @Component

--- a/src/main/java/com/ebikes/iam/constants/ApplicationConstants.java
+++ b/src/main/java/com/ebikes/iam/constants/ApplicationConstants.java
@@ -5,7 +5,7 @@ public final class ApplicationConstants {
   public static final String DOCUMENTATION_ERRORS_BASE = "https://docs.ebikesafrica.co.ke/errors/";
   public static final String ERROR_REFERENCE_PREFIX = "ERR";
   public static final int ERROR_REFERENCE_ID_LENGTH = 6;
-    public static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json";
+  public static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json";
   public static final String REQUEST_ID_HEADER = "X-Request-Id";
   public static final String SYSTEM_ID = "00000000-0000-0000-0000-000000000000";
 

--- a/src/main/java/com/ebikes/iam/constants/EventConstants.java
+++ b/src/main/java/com/ebikes/iam/constants/EventConstants.java
@@ -1,6 +1,7 @@
 package com.ebikes.iam.constants;
 
 import com.ebikes.iam.support.references.ReferenceGenerator;
+
 import lombok.experimental.UtilityClass;
 
 @UtilityClass

--- a/src/main/java/com/ebikes/iam/controllers/ContactController.java
+++ b/src/main/java/com/ebikes/iam/controllers/ContactController.java
@@ -1,13 +1,7 @@
 package com.ebikes.iam.controllers;
 
-import com.ebikes.iam.dtos.requests.filters.ContactFilter;
-import com.ebikes.iam.dtos.responses.api.PaginatedResponse;
-import com.ebikes.iam.dtos.responses.api.SuccessResponse;
-import com.ebikes.iam.dtos.responses.contacts.ContactResponse;
-import com.ebikes.iam.services.contacts.ContactService;
-import com.ebikes.iam.services.users.UserExtensionService;
-import com.ebikes.iam.support.context.ExecutionContext;
-import lombok.RequiredArgsConstructor;
+import java.util.UUID;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -16,7 +10,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.UUID;
+import com.ebikes.iam.dtos.requests.filters.ContactFilter;
+import com.ebikes.iam.dtos.responses.api.PaginatedResponse;
+import com.ebikes.iam.dtos.responses.api.SuccessResponse;
+import com.ebikes.iam.dtos.responses.contacts.ContactResponse;
+import com.ebikes.iam.services.contacts.ContactService;
+import com.ebikes.iam.services.users.UserExtensionService;
+import com.ebikes.iam.support.context.ExecutionContext;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RequestMapping("/contacts")

--- a/src/main/java/com/ebikes/iam/controllers/ContextController.java
+++ b/src/main/java/com/ebikes/iam/controllers/ContextController.java
@@ -1,5 +1,16 @@
 package com.ebikes.iam.controllers;
 
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.ebikes.iam.database.entities.Membership;
 import com.ebikes.iam.dtos.requests.context.SwitchContextRequest;
 import com.ebikes.iam.dtos.responses.api.SuccessResponse;
@@ -8,16 +19,8 @@ import com.ebikes.iam.dtos.responses.memberships.MembershipResponse;
 import com.ebikes.iam.mappers.MembershipMapper;
 import com.ebikes.iam.services.users.ContextService;
 import com.ebikes.iam.support.context.ExecutionContext;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RequestMapping("/contexts")

--- a/src/main/java/com/ebikes/iam/controllers/MembershipController.java
+++ b/src/main/java/com/ebikes/iam/controllers/MembershipController.java
@@ -1,14 +1,9 @@
 package com.ebikes.iam.controllers;
 
-import com.ebikes.iam.database.entities.Membership;
-import com.ebikes.iam.dtos.requests.memberships.CreateMembershipRequest;
-import com.ebikes.iam.dtos.requests.memberships.UpdateMembershipRolesRequest;
-import com.ebikes.iam.dtos.responses.api.SuccessResponse;
-import com.ebikes.iam.dtos.responses.memberships.MembershipResponse;
-import com.ebikes.iam.mappers.MembershipMapper;
-import com.ebikes.iam.services.users.MembershipService;
+import java.util.List;
+
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -22,7 +17,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import com.ebikes.iam.database.entities.Membership;
+import com.ebikes.iam.dtos.requests.memberships.CreateMembershipRequest;
+import com.ebikes.iam.dtos.requests.memberships.UpdateMembershipRolesRequest;
+import com.ebikes.iam.dtos.responses.api.SuccessResponse;
+import com.ebikes.iam.dtos.responses.memberships.MembershipResponse;
+import com.ebikes.iam.mappers.MembershipMapper;
+import com.ebikes.iam.services.users.MembershipService;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RequestMapping("/memberships/{keycloakUserId}")

--- a/src/main/java/com/ebikes/iam/controllers/OutboxController.java
+++ b/src/main/java/com/ebikes/iam/controllers/OutboxController.java
@@ -1,12 +1,9 @@
 package com.ebikes.iam.controllers;
 
-import com.ebikes.iam.dtos.requests.filters.OutboxFilter;
-import com.ebikes.iam.dtos.responses.api.PaginatedResponse;
-import com.ebikes.iam.dtos.responses.api.SuccessResponse;
-import com.ebikes.iam.dtos.responses.outbox.OutboxResponse;
-import com.ebikes.iam.services.events.OutboxService;
+import java.util.UUID;
+
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -16,7 +13,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.UUID;
+import com.ebikes.iam.dtos.requests.filters.OutboxFilter;
+import com.ebikes.iam.dtos.responses.api.PaginatedResponse;
+import com.ebikes.iam.dtos.responses.api.SuccessResponse;
+import com.ebikes.iam.dtos.responses.outbox.OutboxResponse;
+import com.ebikes.iam.services.events.OutboxService;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RequestMapping("/outbox")

--- a/src/main/java/com/ebikes/iam/controllers/PasswordResetController.java
+++ b/src/main/java/com/ebikes/iam/controllers/PasswordResetController.java
@@ -1,17 +1,20 @@
 package com.ebikes.iam.controllers;
 
-import com.ebikes.iam.dtos.requests.passwords.CompletePasswordResetRequest;
-import com.ebikes.iam.dtos.requests.passwords.PasswordResetRequest;
-import com.ebikes.iam.dtos.responses.api.SuccessResponse;
-import com.ebikes.iam.services.verification.VerificationService;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.ebikes.iam.dtos.requests.passwords.CompletePasswordResetRequest;
+import com.ebikes.iam.dtos.requests.passwords.PasswordResetRequest;
+import com.ebikes.iam.dtos.responses.api.SuccessResponse;
+import com.ebikes.iam.services.verification.VerificationService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @RequestMapping("/password-reset")

--- a/src/main/java/com/ebikes/iam/controllers/UserController.java
+++ b/src/main/java/com/ebikes/iam/controllers/UserController.java
@@ -1,21 +1,9 @@
 package com.ebikes.iam.controllers;
 
-import com.ebikes.iam.dtos.requests.filters.UserExtensionFilter;
-import com.ebikes.iam.dtos.requests.users.CreateUserRequest;
-import com.ebikes.iam.dtos.requests.users.SignupRequest;
-import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
-import com.ebikes.iam.dtos.responses.api.PaginatedResponse;
-import com.ebikes.iam.dtos.responses.api.SuccessResponse;
-import com.ebikes.iam.dtos.responses.users.UserExtensionDetailResponse;
-import com.ebikes.iam.dtos.responses.users.UserExtensionSummaryResponse;
-import com.ebikes.iam.dtos.responses.users.UserProfileResponse;
-import com.ebikes.iam.enums.UserStatus;
-import com.ebikes.iam.services.users.UserCreationAuthorizationService;
-import com.ebikes.iam.services.users.UserExtensionService;
-import com.ebikes.iam.services.users.UserProvisioningService;
-import com.ebikes.iam.support.context.ExecutionContext;
+import java.util.UUID;
+
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +18,22 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.UUID;
+import com.ebikes.iam.dtos.requests.filters.UserExtensionFilter;
+import com.ebikes.iam.dtos.requests.users.CreateUserRequest;
+import com.ebikes.iam.dtos.requests.users.SignupRequest;
+import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
+import com.ebikes.iam.dtos.responses.api.PaginatedResponse;
+import com.ebikes.iam.dtos.responses.api.SuccessResponse;
+import com.ebikes.iam.dtos.responses.users.UserExtensionDetailResponse;
+import com.ebikes.iam.dtos.responses.users.UserExtensionSummaryResponse;
+import com.ebikes.iam.dtos.responses.users.UserProfileResponse;
+import com.ebikes.iam.enums.UserStatus;
+import com.ebikes.iam.services.users.UserCreationAuthorizationService;
+import com.ebikes.iam.services.users.UserExtensionService;
+import com.ebikes.iam.services.users.UserProvisioningService;
+import com.ebikes.iam.support.context.ExecutionContext;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RequestMapping("/users")

--- a/src/main/java/com/ebikes/iam/controllers/VerificationController.java
+++ b/src/main/java/com/ebikes/iam/controllers/VerificationController.java
@@ -1,5 +1,13 @@
 package com.ebikes.iam.controllers;
 
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.ebikes.iam.dtos.requests.verification.CompleteAccountActivationRequest;
 import com.ebikes.iam.dtos.requests.verification.CompleteEmailVerificationRequest;
 import com.ebikes.iam.dtos.requests.verification.CompletePhoneVerificationRequest;
@@ -7,14 +15,9 @@ import com.ebikes.iam.dtos.requests.verification.EmailVerificationRequest;
 import com.ebikes.iam.dtos.requests.verification.PhoneVerificationRequest;
 import com.ebikes.iam.dtos.responses.api.SuccessResponse;
 import com.ebikes.iam.services.verification.VerificationService;
-import jakarta.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RequestMapping("/verification")

--- a/src/main/java/com/ebikes/iam/database/entities/Contact.java
+++ b/src/main/java/com/ebikes/iam/database/entities/Contact.java
@@ -1,8 +1,8 @@
 package com.ebikes.iam.database.entities;
 
-import com.ebikes.iam.database.entities.bases.BaseEntity;
-import com.ebikes.iam.enums.ContactSourceType;
-import com.ebikes.iam.enums.ContactStatus;
+import java.io.Serial;
+import java.time.OffsetDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -18,14 +18,16 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
+import com.ebikes.iam.database.entities.bases.BaseEntity;
+import com.ebikes.iam.enums.ContactSourceType;
+import com.ebikes.iam.enums.ContactStatus;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-
-import java.io.Serial;
-import java.time.OffsetDateTime;
 
 @Entity
 @Getter

--- a/src/main/java/com/ebikes/iam/database/entities/Inbox.java
+++ b/src/main/java/com/ebikes/iam/database/entities/Inbox.java
@@ -1,18 +1,19 @@
 package com.ebikes.iam.database.entities;
 
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.io.Serial;
-import java.io.Serializable;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 
 @Entity
 @Getter

--- a/src/main/java/com/ebikes/iam/database/entities/Membership.java
+++ b/src/main/java/com/ebikes/iam/database/entities/Membership.java
@@ -1,6 +1,9 @@
 package com.ebikes.iam.database.entities;
 
-import com.ebikes.iam.database.entities.bases.BaseEntity;
+import java.io.Serial;
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,17 +15,17 @@ import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.ebikes.iam.database.entities.bases.BaseEntity;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
-
-import java.io.Serial;
-import java.util.HashSet;
-import java.util.Set;
 
 @Entity
 @Getter

--- a/src/main/java/com/ebikes/iam/database/entities/Outbox.java
+++ b/src/main/java/com/ebikes/iam/database/entities/Outbox.java
@@ -1,9 +1,9 @@
 package com.ebikes.iam.database.entities;
 
-import com.ebikes.iam.database.entities.bases.BaseEntity;
-import com.ebikes.iam.enums.OutboxStatus;
-import com.ebikes.iam.enums.ResponseCode;
-import com.ebikes.iam.exceptions.ValidationException;
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,16 +12,19 @@ import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.ebikes.iam.database.entities.bases.BaseEntity;
+import com.ebikes.iam.enums.OutboxStatus;
+import com.ebikes.iam.enums.ResponseCode;
+import com.ebikes.iam.exceptions.ValidationException;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
-
-import java.io.Serializable;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 
 @Entity
 @Getter

--- a/src/main/java/com/ebikes/iam/database/entities/Token.java
+++ b/src/main/java/com/ebikes/iam/database/entities/Token.java
@@ -1,7 +1,9 @@
 package com.ebikes.iam.database.entities;
 
-import com.ebikes.iam.database.entities.bases.BaseEntity;
-import com.ebikes.iam.enums.TokenType;
+import java.io.Serial;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,17 +14,18 @@ import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.ebikes.iam.database.entities.bases.BaseEntity;
+import com.ebikes.iam.enums.TokenType;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
-
-import java.io.Serial;
-import java.time.OffsetDateTime;
-import java.util.UUID;
 
 @Entity
 @Getter

--- a/src/main/java/com/ebikes/iam/database/entities/UserExtension.java
+++ b/src/main/java/com/ebikes/iam/database/entities/UserExtension.java
@@ -1,8 +1,9 @@
 package com.ebikes.iam.database.entities;
 
-import com.ebikes.iam.database.entities.bases.SoftDeletableEntity;
-import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
-import com.ebikes.iam.enums.UserStatus;
+import java.io.Serial;
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,17 +19,19 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.ebikes.iam.database.entities.bases.SoftDeletableEntity;
+import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
+import com.ebikes.iam.enums.UserStatus;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
-
-import java.io.Serial;
-import java.util.HashSet;
-import java.util.Set;
 
 @Entity
 @Getter

--- a/src/main/java/com/ebikes/iam/database/entities/bases/BaseEntity.java
+++ b/src/main/java/com/ebikes/iam/database/entities/bases/BaseEntity.java
@@ -1,20 +1,21 @@
 package com.ebikes.iam.database.entities.bases;
 
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-
-import java.io.Serial;
-import java.io.Serializable;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.util.UUID;
 
 @Getter
 @MappedSuperclass

--- a/src/main/java/com/ebikes/iam/database/entities/bases/SoftDeletableEntity.java
+++ b/src/main/java/com/ebikes/iam/database/entities/bases/SoftDeletableEntity.java
@@ -1,13 +1,14 @@
 package com.ebikes.iam.database.entities.bases;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 
 @Getter
 @MappedSuperclass

--- a/src/main/java/com/ebikes/iam/database/repositories/ContactRepository.java
+++ b/src/main/java/com/ebikes/iam/database/repositories/ContactRepository.java
@@ -1,15 +1,16 @@
 package com.ebikes.iam.database.repositories;
 
-import com.ebikes.iam.database.entities.Contact;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.UUID;
+import com.ebikes.iam.database.entities.Contact;
 
 public interface ContactRepository
     extends JpaRepository<Contact, UUID>, JpaSpecificationExecutor<Contact> {
@@ -28,5 +29,4 @@ public interface ContactRepository
 
   List<Contact> findAllByPhoneNumberInAndOrganizationId(
       List<String> phoneNumbers, String organizationId);
-
 }

--- a/src/main/java/com/ebikes/iam/database/repositories/InboxRepository.java
+++ b/src/main/java/com/ebikes/iam/database/repositories/InboxRepository.java
@@ -1,8 +1,9 @@
 package com.ebikes.iam.database.repositories;
 
-import com.ebikes.iam.database.entities.Inbox;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import com.ebikes.iam.database.entities.Inbox;
 
 @Repository
 public interface InboxRepository extends JpaRepository<Inbox, String> {}

--- a/src/main/java/com/ebikes/iam/database/repositories/MembershipRepository.java
+++ b/src/main/java/com/ebikes/iam/database/repositories/MembershipRepository.java
@@ -1,12 +1,13 @@
 package com.ebikes.iam.database.repositories;
 
-import com.ebikes.iam.database.entities.Membership;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.ebikes.iam.database.entities.Membership;
 
 @Repository
 public interface MembershipRepository extends JpaRepository<Membership, UUID> {

--- a/src/main/java/com/ebikes/iam/database/repositories/OutboxRepository.java
+++ b/src/main/java/com/ebikes/iam/database/repositories/OutboxRepository.java
@@ -1,13 +1,14 @@
 package com.ebikes.iam.database.repositories;
 
-import com.ebikes.iam.database.entities.Outbox;
-import com.ebikes.iam.enums.OutboxStatus;
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.UUID;
+import com.ebikes.iam.database.entities.Outbox;
+import com.ebikes.iam.enums.OutboxStatus;
 
 @Repository
 public interface OutboxRepository

--- a/src/main/java/com/ebikes/iam/database/repositories/TokenRepository.java
+++ b/src/main/java/com/ebikes/iam/database/repositories/TokenRepository.java
@@ -1,7 +1,8 @@
 package com.ebikes.iam.database.repositories;
 
-import com.ebikes.iam.database.entities.Token;
-import com.ebikes.iam.enums.TokenType;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,8 +11,8 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-import java.util.UUID;
+import com.ebikes.iam.database.entities.Token;
+import com.ebikes.iam.enums.TokenType;
 
 @Repository
 public interface TokenRepository

--- a/src/main/java/com/ebikes/iam/database/repositories/UserExtensionRepository.java
+++ b/src/main/java/com/ebikes/iam/database/repositories/UserExtensionRepository.java
@@ -1,6 +1,8 @@
 package com.ebikes.iam.database.repositories;
 
-import com.ebikes.iam.database.entities.UserExtension;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -8,8 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-import java.util.UUID;
+import com.ebikes.iam.database.entities.UserExtension;
 
 @Repository
 public interface UserExtensionRepository

--- a/src/main/java/com/ebikes/iam/database/specifications/AuthorizationSpecifications.java
+++ b/src/main/java/com/ebikes/iam/database/specifications/AuthorizationSpecifications.java
@@ -1,16 +1,18 @@
 package com.ebikes.iam.database.specifications;
 
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.data.jpa.domain.Specification;
+
 import com.ebikes.iam.database.entities.Contact;
 import com.ebikes.iam.database.entities.UserExtension;
 import com.ebikes.iam.enums.ResponseCode;
 import com.ebikes.iam.enums.UserRole;
 import com.ebikes.iam.exceptions.AuthorizationException;
 import com.ebikes.iam.support.context.ExecutionContext;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.jpa.domain.Specification;
 
-import java.util.Optional;
-import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class AuthorizationSpecifications {

--- a/src/main/java/com/ebikes/iam/database/specifications/ContactSpecifications.java
+++ b/src/main/java/com/ebikes/iam/database/specifications/ContactSpecifications.java
@@ -1,20 +1,22 @@
 package com.ebikes.iam.database.specifications;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+
+import org.springframework.data.jpa.domain.Specification;
+
 import com.ebikes.iam.database.entities.Contact;
 import com.ebikes.iam.dtos.requests.filters.ContactFilter;
 import com.ebikes.iam.enums.ContactSourceType;
 import com.ebikes.iam.enums.ContactStatus;
 import com.ebikes.iam.support.database.FilterUtilities;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
-import org.springframework.data.jpa.domain.Specification;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 
 public class ContactSpecifications {
 

--- a/src/main/java/com/ebikes/iam/database/specifications/OutboxSpecifications.java
+++ b/src/main/java/com/ebikes/iam/database/specifications/OutboxSpecifications.java
@@ -1,19 +1,21 @@
 package com.ebikes.iam.database.specifications;
 
-import com.ebikes.iam.database.entities.Outbox;
-import com.ebikes.iam.dtos.requests.filters.OutboxFilter;
-import com.ebikes.iam.enums.OutboxStatus;
-import com.ebikes.iam.support.database.FilterUtilities;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
-import org.springframework.data.jpa.domain.Specification;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import com.ebikes.iam.database.entities.Outbox;
+import com.ebikes.iam.dtos.requests.filters.OutboxFilter;
+import com.ebikes.iam.enums.OutboxStatus;
+import com.ebikes.iam.support.database.FilterUtilities;
 
 public class OutboxSpecifications {
 

--- a/src/main/java/com/ebikes/iam/database/specifications/UserExtensionSpecifications.java
+++ b/src/main/java/com/ebikes/iam/database/specifications/UserExtensionSpecifications.java
@@ -1,26 +1,28 @@
 package com.ebikes.iam.database.specifications;
 
-import com.ebikes.iam.database.entities.UserExtension;
-import com.ebikes.iam.dtos.requests.filters.UserExtensionFilter;
-import com.ebikes.iam.enums.UserStatus;
-import com.ebikes.iam.support.database.FilterUtilities;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
-import org.springframework.data.jpa.domain.Specification;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import com.ebikes.iam.database.entities.UserExtension;
+import com.ebikes.iam.dtos.requests.filters.UserExtensionFilter;
+import com.ebikes.iam.enums.UserStatus;
+import com.ebikes.iam.support.database.FilterUtilities;
 
 public class UserExtensionSpecifications {
 
   public static final String FIELD_BRANCH_ID = "branchId";
   public static final String FIELD_COUNTRY_CODE = "countryCode";
   public static final String FIELD_CREATED_AT = "createdAt";
-    public static final String FIELD_EMAIL = "email";
+  public static final String FIELD_EMAIL = "email";
   public static final String FIELD_EMAIL_VERIFIED = "emailVerified";
   public static final String FIELD_FIRST_NAME = "firstName";
   public static final String FIELD_KEYCLOAK_USER_ID = "keycloakUserId";

--- a/src/main/java/com/ebikes/iam/dtos/events/incoming/BatchContactsEvent.java
+++ b/src/main/java/com/ebikes/iam/dtos/events/incoming/BatchContactsEvent.java
@@ -1,10 +1,10 @@
 package com.ebikes.iam.dtos.events.incoming;
 
-import com.ebikes.iam.enums.ContactSourceType;
-
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Set;
+
+import com.ebikes.iam.enums.ContactSourceType;
 
 public record BatchContactsEvent(
     String branchId,

--- a/src/main/java/com/ebikes/iam/dtos/events/incoming/OrganizationApprovedAuditEvent.java
+++ b/src/main/java/com/ebikes/iam/dtos/events/incoming/OrganizationApprovedAuditEvent.java
@@ -1,11 +1,11 @@
 package com.ebikes.iam.dtos.events.incoming;
 
-import com.ebikes.iam.enums.AuditOutcome;
-
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
+
+import com.ebikes.iam.enums.AuditOutcome;
 
 public record OrganizationApprovedAuditEvent(
     UUID entityId,

--- a/src/main/java/com/ebikes/iam/dtos/events/outgoing/AuditEvent.java
+++ b/src/main/java/com/ebikes/iam/dtos/events/outgoing/AuditEvent.java
@@ -1,16 +1,17 @@
 package com.ebikes.iam.dtos.events.outgoing;
 
-import com.ebikes.iam.enums.AuditOutcome;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import static com.ebikes.iam.constants.EventConstants.EventSource;
 
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.ebikes.iam.constants.EventConstants.EventSource;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import com.ebikes.iam.enums.AuditOutcome;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record AuditEvent(

--- a/src/main/java/com/ebikes/iam/dtos/events/outgoing/NotificationRequest.java
+++ b/src/main/java/com/ebikes/iam/dtos/events/outgoing/NotificationRequest.java
@@ -1,14 +1,15 @@
 package com.ebikes.iam.dtos.events.outgoing;
 
-import com.ebikes.iam.enums.ChannelType;
-import com.ebikes.iam.enums.NotificationCategory;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Map;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
-import java.io.Serializable;
-import java.time.Instant;
-import java.util.Map;
+import com.ebikes.iam.enums.ChannelType;
+import com.ebikes.iam.enums.NotificationCategory;
 
 public record NotificationRequest(
     String branchId,

--- a/src/main/java/com/ebikes/iam/dtos/events/outgoing/UserProvisionedEvent.java
+++ b/src/main/java/com/ebikes/iam/dtos/events/outgoing/UserProvisionedEvent.java
@@ -1,10 +1,11 @@
 package com.ebikes.iam.dtos.events.outgoing;
 
-import com.ebikes.iam.constants.EventConstants;
-import jakarta.validation.constraints.NotBlank;
-
 import java.io.Serializable;
 import java.time.Instant;
+
+import jakarta.validation.constraints.NotBlank;
+
+import com.ebikes.iam.constants.EventConstants;
 
 public record UserProvisionedEvent(
     @NotBlank String keycloakUserId,

--- a/src/main/java/com/ebikes/iam/dtos/internal/GeneratedToken.java
+++ b/src/main/java/com/ebikes/iam/dtos/internal/GeneratedToken.java
@@ -1,7 +1,7 @@
 package com.ebikes.iam.dtos.internal;
 
-import com.ebikes.iam.database.entities.Token;
-
 import java.time.OffsetDateTime;
+
+import com.ebikes.iam.database.entities.Token;
 
 public record GeneratedToken(OffsetDateTime expiresAt, String plainToken, Token token) {}

--- a/src/main/java/com/ebikes/iam/dtos/requests/filters/BaseFilter.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/filters/BaseFilter.java
@@ -2,6 +2,7 @@ package com.ebikes.iam.dtos.requests.filters;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/ebikes/iam/dtos/requests/filters/ContactFilter.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/filters/ContactFilter.java
@@ -1,12 +1,13 @@
 package com.ebikes.iam.dtos.requests.filters;
 
+import java.time.LocalDate;
+
 import com.ebikes.iam.enums.ContactSourceType;
 import com.ebikes.iam.enums.ContactStatus;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 
 @Data
 @NoArgsConstructor

--- a/src/main/java/com/ebikes/iam/dtos/requests/filters/OutboxFilter.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/filters/OutboxFilter.java
@@ -1,11 +1,12 @@
 package com.ebikes.iam.dtos.requests.filters;
 
+import java.time.LocalDate;
+
 import com.ebikes.iam.enums.OutboxStatus;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 
 @Data
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/com/ebikes/iam/dtos/requests/filters/UserExtensionFilter.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/filters/UserExtensionFilter.java
@@ -1,11 +1,12 @@
 package com.ebikes.iam.dtos.requests.filters;
 
+import java.time.LocalDate;
+
 import com.ebikes.iam.enums.UserStatus;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 
 @Data
 @NoArgsConstructor

--- a/src/main/java/com/ebikes/iam/dtos/requests/memberships/CreateMembershipRequest.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/memberships/CreateMembershipRequest.java
@@ -1,12 +1,13 @@
 package com.ebikes.iam.dtos.requests.memberships;
 
-import com.ebikes.iam.enums.UserRole;
+import java.io.Serializable;
+import java.util.Set;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
-import java.io.Serializable;
-import java.util.Set;
+import com.ebikes.iam.enums.UserRole;
 
 public record CreateMembershipRequest(
     String branchId,

--- a/src/main/java/com/ebikes/iam/dtos/requests/memberships/UpdateMembershipRolesRequest.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/memberships/UpdateMembershipRolesRequest.java
@@ -1,10 +1,11 @@
 package com.ebikes.iam.dtos.requests.memberships;
 
-import com.ebikes.iam.enums.UserRole;
-import jakarta.validation.constraints.NotEmpty;
-
 import java.io.Serializable;
 import java.util.Set;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import com.ebikes.iam.enums.UserRole;
 
 public record UpdateMembershipRolesRequest(@NotEmpty Set<UserRole> roles) implements Serializable {
   public UpdateMembershipRolesRequest {

--- a/src/main/java/com/ebikes/iam/dtos/requests/users/CreateUserRequest.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/users/CreateUserRequest.java
@@ -1,15 +1,17 @@
 package com.ebikes.iam.dtos.requests.users;
 
-import com.ebikes.iam.enums.UserRole;
+import java.io.Serializable;
+import java.util.Set;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
 import org.hibernate.validator.constraints.Length;
 
-import java.io.Serializable;
-import java.util.Set;
+import com.ebikes.iam.enums.UserRole;
 
 public record CreateUserRequest(
     @Length(min = 36, max = 36) String branchId,

--- a/src/main/java/com/ebikes/iam/dtos/requests/users/UpdateUserExtensionRequest.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/users/UpdateUserExtensionRequest.java
@@ -1,12 +1,13 @@
 package com.ebikes.iam.dtos.requests.users;
 
-import com.ebikes.iam.enums.UserStatus;
-import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.UUID;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
-import java.util.UUID;
+import com.ebikes.iam.enums.UserStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record UpdateUserExtensionRequest(

--- a/src/main/java/com/ebikes/iam/dtos/requests/verification/CompleteAccountActivationRequest.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/verification/CompleteAccountActivationRequest.java
@@ -1,9 +1,9 @@
 package com.ebikes.iam.dtos.requests.verification;
 
+import java.io.Serializable;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-
-import java.io.Serializable;
 
 public record CompleteAccountActivationRequest(
     @NotBlank(message = "Password is required") @Size(min = 8, message = "Password must be at least 8 characters") String password,

--- a/src/main/java/com/ebikes/iam/dtos/requests/verification/CompleteEmailVerificationRequest.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/verification/CompleteEmailVerificationRequest.java
@@ -1,8 +1,8 @@
 package com.ebikes.iam.dtos.requests.verification;
 
-import jakarta.validation.constraints.NotBlank;
-
 import java.io.Serializable;
+
+import jakarta.validation.constraints.NotBlank;
 
 public record CompleteEmailVerificationRequest(@NotBlank(message = "Token is required") String code)
     implements Serializable {}

--- a/src/main/java/com/ebikes/iam/dtos/requests/verification/CompletePhoneVerificationRequest.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/verification/CompletePhoneVerificationRequest.java
@@ -1,8 +1,8 @@
 package com.ebikes.iam.dtos.requests.verification;
 
-import jakarta.validation.constraints.NotBlank;
-
 import java.io.Serializable;
+
+import jakarta.validation.constraints.NotBlank;
 
 public record CompletePhoneVerificationRequest(@NotBlank(message = "Code is required") String code)
     implements Serializable {}

--- a/src/main/java/com/ebikes/iam/dtos/requests/verification/EmailVerificationRequest.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/verification/EmailVerificationRequest.java
@@ -1,9 +1,9 @@
 package com.ebikes.iam.dtos.requests.verification;
 
+import java.io.Serializable;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-
-import java.io.Serializable;
 
 public record EmailVerificationRequest(
     @NotBlank(message = "Email is required") @Email(message = "Invalid email format") String email)

--- a/src/main/java/com/ebikes/iam/dtos/requests/verification/PhoneVerificationRequest.java
+++ b/src/main/java/com/ebikes/iam/dtos/requests/verification/PhoneVerificationRequest.java
@@ -1,8 +1,8 @@
 package com.ebikes.iam.dtos.requests.verification;
 
-import jakarta.validation.constraints.NotBlank;
-
 import java.io.Serializable;
+
+import jakarta.validation.constraints.NotBlank;
 
 public record PhoneVerificationRequest(
     @NotBlank(message = "Phone number is required") String phoneNumber) implements Serializable {}

--- a/src/main/java/com/ebikes/iam/dtos/responses/api/ErrorResponse.java
+++ b/src/main/java/com/ebikes/iam/dtos/responses/api/ErrorResponse.java
@@ -1,11 +1,11 @@
 package com.ebikes.iam.dtos.responses.api;
 
-import com.ebikes.iam.enums.ResponseCode;
-import com.fasterxml.jackson.annotation.JsonInclude;
+import static com.ebikes.iam.constants.ApplicationConstants.DOCUMENTATION_ERRORS_BASE;
 
 import java.util.List;
 
-import static com.ebikes.iam.constants.ApplicationConstants.DOCUMENTATION_ERRORS_BASE;
+import com.ebikes.iam.enums.ResponseCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ErrorResponse(

--- a/src/main/java/com/ebikes/iam/dtos/responses/api/PaginatedResponse.java
+++ b/src/main/java/com/ebikes/iam/dtos/responses/api/PaginatedResponse.java
@@ -1,9 +1,10 @@
 package com.ebikes.iam.dtos.responses.api;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record PaginatedResponse<T>(

--- a/src/main/java/com/ebikes/iam/dtos/responses/contacts/ContactResponse.java
+++ b/src/main/java/com/ebikes/iam/dtos/responses/contacts/ContactResponse.java
@@ -1,12 +1,12 @@
 package com.ebikes.iam.dtos.responses.contacts;
 
-import com.ebikes.iam.enums.ContactSourceType;
-import com.ebikes.iam.enums.ContactStatus;
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.UUID;
+
+import com.ebikes.iam.enums.ContactSourceType;
+import com.ebikes.iam.enums.ContactStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ContactResponse(

--- a/src/main/java/com/ebikes/iam/dtos/responses/context/ContextResponse.java
+++ b/src/main/java/com/ebikes/iam/dtos/responses/context/ContextResponse.java
@@ -1,12 +1,13 @@
 package com.ebikes.iam.dtos.responses.context;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Set;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ContextResponse(

--- a/src/main/java/com/ebikes/iam/dtos/responses/memberships/MembershipResponse.java
+++ b/src/main/java/com/ebikes/iam/dtos/responses/memberships/MembershipResponse.java
@@ -1,10 +1,10 @@
 package com.ebikes.iam.dtos.responses.memberships;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import java.io.Serializable;
 import java.util.Set;
 import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record MembershipResponse(

--- a/src/main/java/com/ebikes/iam/dtos/responses/outbox/OutboxResponse.java
+++ b/src/main/java/com/ebikes/iam/dtos/responses/outbox/OutboxResponse.java
@@ -1,11 +1,11 @@
 package com.ebikes.iam.dtos.responses.outbox;
 
-import com.ebikes.iam.enums.OutboxStatus;
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.UUID;
+
+import com.ebikes.iam.enums.OutboxStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record OutboxResponse(

--- a/src/main/java/com/ebikes/iam/dtos/responses/users/UserExtensionDetailResponse.java
+++ b/src/main/java/com/ebikes/iam/dtos/responses/users/UserExtensionDetailResponse.java
@@ -1,11 +1,11 @@
 package com.ebikes.iam.dtos.responses.users;
 
-import com.ebikes.iam.enums.UserStatus;
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.UUID;
+
+import com.ebikes.iam.enums.UserStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record UserExtensionDetailResponse(

--- a/src/main/java/com/ebikes/iam/dtos/responses/users/UserExtensionSummaryResponse.java
+++ b/src/main/java/com/ebikes/iam/dtos/responses/users/UserExtensionSummaryResponse.java
@@ -1,10 +1,10 @@
 package com.ebikes.iam.dtos.responses.users;
 
-import com.ebikes.iam.enums.UserStatus;
-
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.UUID;
+
+import com.ebikes.iam.enums.UserStatus;
 
 public record UserExtensionSummaryResponse(
     OffsetDateTime createdAt,

--- a/src/main/java/com/ebikes/iam/dtos/responses/users/UserProfileResponse.java
+++ b/src/main/java/com/ebikes/iam/dtos/responses/users/UserProfileResponse.java
@@ -1,12 +1,12 @@
 package com.ebikes.iam.dtos.responses.users;
 
-import com.ebikes.iam.dtos.responses.memberships.MembershipResponse;
-import com.ebikes.iam.enums.UserStatus;
-
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
+
+import com.ebikes.iam.dtos.responses.memberships.MembershipResponse;
+import com.ebikes.iam.enums.UserStatus;
 
 public record UserProfileResponse(
     MembershipResponse activeMembership,

--- a/src/main/java/com/ebikes/iam/enums/ResponseCode.java
+++ b/src/main/java/com/ebikes/iam/enums/ResponseCode.java
@@ -1,10 +1,11 @@
 package com.ebikes.iam.enums;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import static com.ebikes.iam.constants.EventConstants.EventSource.HOST_SERVICE;
+
 import org.springframework.http.HttpStatus;
 
-import static com.ebikes.iam.constants.EventConstants.EventSource.HOST_SERVICE;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/com/ebikes/iam/exceptions/AuthorizationException.java
+++ b/src/main/java/com/ebikes/iam/exceptions/AuthorizationException.java
@@ -1,8 +1,8 @@
 package com.ebikes.iam.exceptions;
 
-import com.ebikes.iam.enums.ResponseCode;
-
 import java.io.Serial;
+
+import com.ebikes.iam.enums.ResponseCode;
 
 public class AuthorizationException extends BaseException {
 

--- a/src/main/java/com/ebikes/iam/exceptions/BaseException.java
+++ b/src/main/java/com/ebikes/iam/exceptions/BaseException.java
@@ -1,9 +1,10 @@
 package com.ebikes.iam.exceptions;
 
-import com.ebikes.iam.enums.ResponseCode;
-import lombok.Getter;
-
 import java.io.Serial;
+
+import com.ebikes.iam.enums.ResponseCode;
+
+import lombok.Getter;
 
 @Getter
 public abstract class BaseException extends RuntimeException {

--- a/src/main/java/com/ebikes/iam/exceptions/BusinessRuleException.java
+++ b/src/main/java/com/ebikes/iam/exceptions/BusinessRuleException.java
@@ -1,8 +1,8 @@
 package com.ebikes.iam.exceptions;
 
-import com.ebikes.iam.enums.ResponseCode;
-
 import java.io.Serial;
+
+import com.ebikes.iam.enums.ResponseCode;
 
 public class BusinessRuleException extends BaseException {
 

--- a/src/main/java/com/ebikes/iam/exceptions/DuplicateResourceException.java
+++ b/src/main/java/com/ebikes/iam/exceptions/DuplicateResourceException.java
@@ -1,8 +1,8 @@
 package com.ebikes.iam.exceptions;
 
-import com.ebikes.iam.enums.ResponseCode;
-
 import java.io.Serial;
+
+import com.ebikes.iam.enums.ResponseCode;
 
 public class DuplicateResourceException extends BaseException {
 

--- a/src/main/java/com/ebikes/iam/exceptions/ExternalServiceException.java
+++ b/src/main/java/com/ebikes/iam/exceptions/ExternalServiceException.java
@@ -1,9 +1,10 @@
 package com.ebikes.iam.exceptions;
 
-import com.ebikes.iam.enums.ResponseCode;
-import lombok.Getter;
-
 import java.io.Serial;
+
+import com.ebikes.iam.enums.ResponseCode;
+
+import lombok.Getter;
 
 @Getter
 public class ExternalServiceException extends BaseException {

--- a/src/main/java/com/ebikes/iam/exceptions/RateLimitException.java
+++ b/src/main/java/com/ebikes/iam/exceptions/RateLimitException.java
@@ -1,8 +1,8 @@
 package com.ebikes.iam.exceptions;
 
-import com.ebikes.iam.enums.ResponseCode;
-
 import java.io.Serial;
+
+import com.ebikes.iam.enums.ResponseCode;
 
 public class RateLimitException extends BaseException {
 

--- a/src/main/java/com/ebikes/iam/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/com/ebikes/iam/exceptions/ResourceNotFoundException.java
@@ -1,8 +1,8 @@
 package com.ebikes.iam.exceptions;
 
-import com.ebikes.iam.enums.ResponseCode;
-
 import java.io.Serial;
+
+import com.ebikes.iam.enums.ResponseCode;
 
 public class ResourceNotFoundException extends BaseException {
 

--- a/src/main/java/com/ebikes/iam/exceptions/ValidationException.java
+++ b/src/main/java/com/ebikes/iam/exceptions/ValidationException.java
@@ -1,10 +1,11 @@
 package com.ebikes.iam.exceptions;
 
-import com.ebikes.iam.enums.ResponseCode;
-import lombok.Getter;
-
 import java.io.Serial;
 import java.io.Serializable;
+
+import com.ebikes.iam.enums.ResponseCode;
+
+import lombok.Getter;
 
 @Getter
 public class ValidationException extends BaseException {

--- a/src/main/java/com/ebikes/iam/exceptions/handlers/GlobalExceptionHandler.java
+++ b/src/main/java/com/ebikes/iam/exceptions/handlers/GlobalExceptionHandler.java
@@ -1,14 +1,9 @@
 package com.ebikes.iam.exceptions.handlers;
 
-import com.ebikes.iam.dtos.responses.api.ErrorResponse;
-import com.ebikes.iam.dtos.responses.api.ErrorResponse.ErrorDetail;
-import com.ebikes.iam.enums.ResponseCode;
-import com.ebikes.iam.exceptions.BaseException;
-import com.ebikes.iam.exceptions.ExternalServiceException;
-import com.ebikes.iam.exceptions.ValidationException;
-import com.ebikes.iam.support.web.ErrorResponseBuilder;
+import java.util.List;
+
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -17,7 +12,15 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
-import java.util.List;
+import com.ebikes.iam.dtos.responses.api.ErrorResponse;
+import com.ebikes.iam.dtos.responses.api.ErrorResponse.ErrorDetail;
+import com.ebikes.iam.enums.ResponseCode;
+import com.ebikes.iam.exceptions.BaseException;
+import com.ebikes.iam.exceptions.ExternalServiceException;
+import com.ebikes.iam.exceptions.ValidationException;
+import com.ebikes.iam.support.web.ErrorResponseBuilder;
+
+import lombok.extern.slf4j.Slf4j;
 
 @RestControllerAdvice
 @Slf4j

--- a/src/main/java/com/ebikes/iam/listeners/IncomingEventListener.java
+++ b/src/main/java/com/ebikes/iam/listeners/IncomingEventListener.java
@@ -1,12 +1,14 @@
 package com.ebikes.iam.listeners;
 
-import com.ebikes.iam.support.context.EventContext;
-import com.ebikes.iam.support.events.EventContextDecorator;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import com.ebikes.iam.support.context.EventContext;
+import com.ebikes.iam.support.events.EventContextDecorator;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j

--- a/src/main/java/com/ebikes/iam/listeners/OrderEventsListener.java
+++ b/src/main/java/com/ebikes/iam/listeners/OrderEventsListener.java
@@ -1,13 +1,15 @@
 package com.ebikes.iam.listeners;
 
+import org.springframework.stereotype.Component;
+
 import com.ebikes.iam.constants.EventConstants.RoutingKeys;
 import com.ebikes.iam.dtos.events.incoming.BatchContactsEvent;
 import com.ebikes.iam.services.contacts.ContactService;
 import com.ebikes.iam.services.events.InboxService;
 import com.ebikes.iam.support.context.EventContext;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 import tools.jackson.databind.ObjectMapper;
 
 @Component

--- a/src/main/java/com/ebikes/iam/listeners/OrganizationEventListener.java
+++ b/src/main/java/com/ebikes/iam/listeners/OrganizationEventListener.java
@@ -1,5 +1,9 @@
 package com.ebikes.iam.listeners;
 
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
 import com.ebikes.iam.constants.EventConstants.RoutingKeys;
 import com.ebikes.iam.dtos.events.incoming.OrganizationApprovedAuditEvent;
 import com.ebikes.iam.dtos.requests.memberships.CreateMembershipRequest;
@@ -9,12 +13,10 @@ import com.ebikes.iam.services.events.InboxService;
 import com.ebikes.iam.services.keycloak.groups.KeycloakGroupService;
 import com.ebikes.iam.services.users.MembershipService;
 import com.ebikes.iam.support.context.EventContext;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 import tools.jackson.databind.ObjectMapper;
-
-import java.util.Set;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/ebikes/iam/listeners/UserProvisioningEventListener.java
+++ b/src/main/java/com/ebikes/iam/listeners/UserProvisioningEventListener.java
@@ -1,14 +1,16 @@
 package com.ebikes.iam.listeners;
 
-import com.ebikes.iam.dtos.internal.UserProvisionedApplicationEvent;
-import com.ebikes.iam.services.notifications.NotificationService;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.ebikes.iam.dtos.internal.UserProvisionedApplicationEvent;
+import com.ebikes.iam.services.notifications.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/ebikes/iam/mappers/ContactMapper.java
+++ b/src/main/java/com/ebikes/iam/mappers/ContactMapper.java
@@ -1,11 +1,12 @@
 package com.ebikes.iam.mappers;
 
-import com.ebikes.iam.database.entities.Contact;
-import com.ebikes.iam.dtos.responses.contacts.ContactResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.ReportingPolicy;
+
+import com.ebikes.iam.database.entities.Contact;
+import com.ebikes.iam.dtos.responses.contacts.ContactResponse;
 
 @Mapper(
     componentModel = "spring",

--- a/src/main/java/com/ebikes/iam/mappers/KeycloakUserMapper.java
+++ b/src/main/java/com/ebikes/iam/mappers/KeycloakUserMapper.java
@@ -1,13 +1,15 @@
 package com.ebikes.iam.mappers;
 
-import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
+import java.util.List;
+
 import jakarta.validation.constraints.NotBlank;
+
 import org.keycloak.representations.idm.UserRepresentation;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.ReportingPolicy;
 
-import java.util.List;
+import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface KeycloakUserMapper {

--- a/src/main/java/com/ebikes/iam/mappers/MembershipMapper.java
+++ b/src/main/java/com/ebikes/iam/mappers/MembershipMapper.java
@@ -1,16 +1,17 @@
 package com.ebikes.iam.mappers;
 
-import com.ebikes.iam.database.entities.Membership;
-import com.ebikes.iam.dtos.events.incoming.OrganizationApprovedAuditEvent;
-import com.ebikes.iam.dtos.requests.memberships.CreateMembershipRequest;
-import com.ebikes.iam.dtos.responses.memberships.MembershipResponse;
-import com.ebikes.iam.enums.UserRole;
+import java.util.Set;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.ReportingPolicy;
 
-import java.util.Set;
+import com.ebikes.iam.database.entities.Membership;
+import com.ebikes.iam.dtos.events.incoming.OrganizationApprovedAuditEvent;
+import com.ebikes.iam.dtos.requests.memberships.CreateMembershipRequest;
+import com.ebikes.iam.dtos.responses.memberships.MembershipResponse;
+import com.ebikes.iam.enums.UserRole;
 
 @Mapper(
     componentModel = "spring",

--- a/src/main/java/com/ebikes/iam/mappers/NotificationMapper.java
+++ b/src/main/java/com/ebikes/iam/mappers/NotificationMapper.java
@@ -1,14 +1,15 @@
 package com.ebikes.iam.mappers;
 
+import java.io.Serializable;
+import java.util.Map;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
 import com.ebikes.iam.constants.EventConstants.EventTypes;
 import com.ebikes.iam.constants.EventConstants.TemplateNames;
 import com.ebikes.iam.database.entities.UserExtension;
 import com.ebikes.iam.dtos.events.outgoing.NotificationRequest;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-
-import java.io.Serializable;
-import java.util.Map;
 
 @Mapper(componentModel = "spring")
 public interface NotificationMapper {

--- a/src/main/java/com/ebikes/iam/mappers/OutboxMapper.java
+++ b/src/main/java/com/ebikes/iam/mappers/OutboxMapper.java
@@ -1,8 +1,9 @@
 package com.ebikes.iam.mappers;
 
+import org.mapstruct.Mapper;
+
 import com.ebikes.iam.database.entities.Outbox;
 import com.ebikes.iam.dtos.responses.outbox.OutboxResponse;
-import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface OutboxMapper {

--- a/src/main/java/com/ebikes/iam/mappers/TokenMapper.java
+++ b/src/main/java/com/ebikes/iam/mappers/TokenMapper.java
@@ -1,13 +1,14 @@
 package com.ebikes.iam.mappers;
 
-import com.ebikes.iam.database.entities.Token;
-import com.ebikes.iam.enums.TokenType;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
-import java.time.OffsetDateTime;
-import java.util.UUID;
+import com.ebikes.iam.database.entities.Token;
+import com.ebikes.iam.enums.TokenType;
 
 @Mapper(
     componentModel = "spring",

--- a/src/main/java/com/ebikes/iam/mappers/UserExtensionMapper.java
+++ b/src/main/java/com/ebikes/iam/mappers/UserExtensionMapper.java
@@ -1,16 +1,17 @@
 package com.ebikes.iam.mappers;
 
-import com.ebikes.iam.database.entities.Membership;
-import com.ebikes.iam.database.entities.UserExtension;
-import com.ebikes.iam.dtos.responses.users.UserExtensionDetailResponse;
-import com.ebikes.iam.dtos.responses.users.UserExtensionSummaryResponse;
-import com.ebikes.iam.dtos.responses.users.UserProfileResponse;
+import java.util.List;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.ReportingPolicy;
 
-import java.util.List;
+import com.ebikes.iam.database.entities.Membership;
+import com.ebikes.iam.database.entities.UserExtension;
+import com.ebikes.iam.dtos.responses.users.UserExtensionDetailResponse;
+import com.ebikes.iam.dtos.responses.users.UserExtensionSummaryResponse;
+import com.ebikes.iam.dtos.responses.users.UserProfileResponse;
 
 @Mapper(
     componentModel = "spring",

--- a/src/main/java/com/ebikes/iam/publishers/AuditEventPublisher.java
+++ b/src/main/java/com/ebikes/iam/publishers/AuditEventPublisher.java
@@ -1,11 +1,13 @@
 package com.ebikes.iam.publishers;
 
-import com.ebikes.iam.dtos.events.outgoing.AuditEvent;
-import com.ebikes.iam.services.events.OutboxService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.ebikes.iam.dtos.events.outgoing.AuditEvent;
+import com.ebikes.iam.services.events.OutboxService;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/ebikes/iam/publishers/NotificationEventPublisher.java
+++ b/src/main/java/com/ebikes/iam/publishers/NotificationEventPublisher.java
@@ -1,13 +1,15 @@
 package com.ebikes.iam.publishers;
 
+import org.springframework.stereotype.Component;
+
 import com.ebikes.iam.configurations.properties.NotificationProperties;
 import com.ebikes.iam.constants.EventConstants.RoutingKeys;
 import com.ebikes.iam.dtos.events.outgoing.NotificationRequest;
 import com.ebikes.iam.enums.ChannelType;
 import com.ebikes.iam.services.events.OutboxService;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/ebikes/iam/publishers/OutboxPublisher.java
+++ b/src/main/java/com/ebikes/iam/publishers/OutboxPublisher.java
@@ -1,15 +1,17 @@
 package com.ebikes.iam.publishers;
 
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
 import com.ebikes.iam.database.entities.Outbox;
 import com.ebikes.iam.database.repositories.OutboxRepository;
 import com.ebikes.iam.enums.OutboxStatus;
 import com.ebikes.iam.services.events.OutboxEventProcessor;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/ebikes/iam/publishers/UserConfigurationEventPublisher.java
+++ b/src/main/java/com/ebikes/iam/publishers/UserConfigurationEventPublisher.java
@@ -1,14 +1,16 @@
 package com.ebikes.iam.publishers;
 
+import org.springframework.stereotype.Component;
+
 import com.ebikes.iam.constants.EventConstants.EventSource;
 import com.ebikes.iam.constants.EventConstants.EventTypes;
 import com.ebikes.iam.constants.EventConstants.RoutingKeys;
 import com.ebikes.iam.database.entities.UserExtension;
 import com.ebikes.iam.dtos.events.outgoing.UserProvisionedEvent;
 import com.ebikes.iam.services.events.OutboxService;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/ebikes/iam/services/contacts/ContactService.java
+++ b/src/main/java/com/ebikes/iam/services/contacts/ContactService.java
@@ -1,5 +1,20 @@
 package com.ebikes.iam.services.contacts;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.ebikes.iam.configurations.properties.ContactProperties;
 import com.ebikes.iam.constants.EventConstants;
 import com.ebikes.iam.constants.EventConstants.EventTypes;
@@ -22,22 +37,9 @@ import com.ebikes.iam.support.audit.AuditContext;
 import com.ebikes.iam.support.audit.AuditMetadataBuilder;
 import com.ebikes.iam.support.audit.AuditTemplate;
 import com.ebikes.iam.support.database.FilterUtilities;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/events/InboxService.java
+++ b/src/main/java/com/ebikes/iam/services/events/InboxService.java
@@ -1,13 +1,15 @@
 package com.ebikes.iam.services.events;
 
-import com.ebikes.iam.database.entities.Inbox;
-import com.ebikes.iam.database.repositories.InboxRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
+
+import com.ebikes.iam.database.entities.Inbox;
+import com.ebikes.iam.database.repositories.InboxRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/events/OutboxEventProcessor.java
+++ b/src/main/java/com/ebikes/iam/services/events/OutboxEventProcessor.java
@@ -1,16 +1,18 @@
 package com.ebikes.iam.services.events;
 
-import com.ebikes.iam.constants.ApplicationConstants;
-import com.ebikes.iam.constants.EventConstants.MessageHeaders;
-import com.ebikes.iam.database.entities.Outbox;
-import com.ebikes.iam.database.repositories.OutboxRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.ebikes.iam.constants.ApplicationConstants;
+import com.ebikes.iam.constants.EventConstants.MessageHeaders;
+import com.ebikes.iam.database.entities.Outbox;
+import com.ebikes.iam.database.repositories.OutboxRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/ebikes/iam/services/events/OutboxService.java
+++ b/src/main/java/com/ebikes/iam/services/events/OutboxService.java
@@ -1,5 +1,15 @@
 package com.ebikes.iam.services.events;
 
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.ebikes.iam.database.entities.Outbox;
 import com.ebikes.iam.database.repositories.OutboxRepository;
 import com.ebikes.iam.database.specifications.OutboxSpecifications;
@@ -11,17 +21,9 @@ import com.ebikes.iam.enums.ResponseCode;
 import com.ebikes.iam.exceptions.ResourceNotFoundException;
 import com.ebikes.iam.mappers.OutboxMapper;
 import com.ebikes.iam.support.database.FilterUtilities;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.io.Serializable;
-import java.util.List;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/keycloak/groups/KeycloakGroupService.java
+++ b/src/main/java/com/ebikes/iam/services/keycloak/groups/KeycloakGroupService.java
@@ -1,14 +1,12 @@
 package com.ebikes.iam.services.keycloak.groups;
 
-import com.ebikes.iam.configurations.properties.KeycloakProperties;
-import com.ebikes.iam.enums.ResponseCode;
-import com.ebikes.iam.exceptions.ExternalServiceException;
-import com.ebikes.iam.exceptions.ResourceNotFoundException;
-import com.ebikes.iam.support.keycloak.GroupPathUtilities;
-import com.ebikes.iam.support.keycloak.KeycloakResponseUtilities;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import jakarta.ws.rs.core.Response;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.GroupsResource;
 import org.keycloak.admin.client.resource.RealmResource;
@@ -16,10 +14,15 @@ import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import com.ebikes.iam.configurations.properties.KeycloakProperties;
+import com.ebikes.iam.enums.ResponseCode;
+import com.ebikes.iam.exceptions.ExternalServiceException;
+import com.ebikes.iam.exceptions.ResourceNotFoundException;
+import com.ebikes.iam.support.keycloak.GroupPathUtilities;
+import com.ebikes.iam.support.keycloak.KeycloakResponseUtilities;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/keycloak/users/KeycloakUserService.java
+++ b/src/main/java/com/ebikes/iam/services/keycloak/users/KeycloakUserService.java
@@ -1,14 +1,13 @@
 package com.ebikes.iam.services.keycloak.users;
 
-import com.ebikes.iam.configurations.properties.KeycloakProperties;
-import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
-import com.ebikes.iam.enums.ResponseCode;
-import com.ebikes.iam.exceptions.ExternalServiceException;
-import com.ebikes.iam.mappers.KeycloakUserMapper;
-import com.ebikes.iam.support.keycloak.KeycloakResponseUtilities;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
 import jakarta.ws.rs.core.Response;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
@@ -17,11 +16,15 @@ import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import com.ebikes.iam.configurations.properties.KeycloakProperties;
+import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
+import com.ebikes.iam.enums.ResponseCode;
+import com.ebikes.iam.exceptions.ExternalServiceException;
+import com.ebikes.iam.mappers.KeycloakUserMapper;
+import com.ebikes.iam.support.keycloak.KeycloakResponseUtilities;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/notifications/NotificationService.java
+++ b/src/main/java/com/ebikes/iam/services/notifications/NotificationService.java
@@ -1,5 +1,12 @@
 package com.ebikes.iam.services.notifications;
 
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
 import com.ebikes.iam.constants.EventConstants.EventSource;
 import com.ebikes.iam.database.entities.UserExtension;
 import com.ebikes.iam.dtos.events.outgoing.NotificationRequest;
@@ -9,14 +16,9 @@ import com.ebikes.iam.mappers.NotificationMapper;
 import com.ebikes.iam.publishers.NotificationEventPublisher;
 import com.ebikes.iam.services.tokens.TokenService;
 import com.ebikes.iam.services.verification.VerificationLinkBuilder;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-
-import java.io.Serializable;
-import java.time.OffsetDateTime;
-import java.util.HashMap;
-import java.util.Map;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/security/RateLimitService.java
+++ b/src/main/java/com/ebikes/iam/services/security/RateLimitService.java
@@ -1,17 +1,19 @@
 package com.ebikes.iam.services.security;
 
-import com.ebikes.iam.configurations.properties.RateLimitProperties;
-import com.ebikes.iam.configurations.properties.RateLimitProperties.ResendLimits;
-import com.ebikes.iam.enums.ResponseCode;
-import com.ebikes.iam.exceptions.RateLimitException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.time.Duration;
+import java.util.List;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
-import java.util.List;
+import com.ebikes.iam.configurations.properties.RateLimitProperties;
+import com.ebikes.iam.configurations.properties.RateLimitProperties.ResendLimits;
+import com.ebikes.iam.enums.ResponseCode;
+import com.ebikes.iam.exceptions.RateLimitException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/tokens/TokenService.java
+++ b/src/main/java/com/ebikes/iam/services/tokens/TokenService.java
@@ -1,5 +1,15 @@
 package com.ebikes.iam.services.tokens;
 
+import java.security.SecureRandom;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.UUID;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.ebikes.iam.configurations.properties.TokenProperties;
 import com.ebikes.iam.configurations.properties.TokenProperties.TokenConfiguration;
 import com.ebikes.iam.database.entities.Token;
@@ -11,17 +21,9 @@ import com.ebikes.iam.exceptions.ResourceNotFoundException;
 import com.ebikes.iam.exceptions.ValidationException;
 import com.ebikes.iam.mappers.TokenMapper;
 import com.ebikes.iam.support.security.TokenHashUtilities;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.security.SecureRandom;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.util.Base64;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/users/ContextService.java
+++ b/src/main/java/com/ebikes/iam/services/users/ContextService.java
@@ -1,5 +1,15 @@
 package com.ebikes.iam.services.users;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.validation.constraints.NotBlank;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
 import com.ebikes.iam.constants.ApplicationConstants;
 import com.ebikes.iam.constants.EventConstants.EventTypes;
 import com.ebikes.iam.constants.EventConstants.RoutingKeys;
@@ -10,16 +20,9 @@ import com.ebikes.iam.services.keycloak.users.KeycloakUserService;
 import com.ebikes.iam.support.audit.AuditContext;
 import com.ebikes.iam.support.audit.AuditMetadataBuilder;
 import com.ebikes.iam.support.audit.AuditTemplate;
-import jakarta.validation.constraints.NotBlank;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.annotation.Validated;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/users/MembershipService.java
+++ b/src/main/java/com/ebikes/iam/services/users/MembershipService.java
@@ -1,5 +1,15 @@
 package com.ebikes.iam.services.users;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
 import com.ebikes.iam.configurations.properties.KeycloakProperties;
 import com.ebikes.iam.constants.EventConstants.EventTypes;
 import com.ebikes.iam.constants.EventConstants.RoutingKeys;
@@ -17,17 +27,9 @@ import com.ebikes.iam.support.audit.AuditContext;
 import com.ebikes.iam.support.audit.AuditMetadataBuilder;
 import com.ebikes.iam.support.audit.AuditTemplate;
 import com.ebikes.iam.support.keycloak.GroupPathUtilities;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.annotation.Validated;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/users/UserCreationAuthorizationService.java
+++ b/src/main/java/com/ebikes/iam/services/users/UserCreationAuthorizationService.java
@@ -1,21 +1,23 @@
 package com.ebikes.iam.services.users;
 
+import static com.ebikes.iam.support.security.RBACUtilities.getRequiredAuthorityToCreate;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.ebikes.iam.database.entities.Membership;
 import com.ebikes.iam.enums.ResponseCode;
 import com.ebikes.iam.enums.UserRole;
 import com.ebikes.iam.exceptions.AuthorizationException;
 import com.ebikes.iam.support.context.ExecutionContext;
 import com.ebikes.iam.support.security.RBACUtilities;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.ebikes.iam.support.security.RBACUtilities.getRequiredAuthorityToCreate;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/users/UserExtensionService.java
+++ b/src/main/java/com/ebikes/iam/services/users/UserExtensionService.java
@@ -1,5 +1,18 @@
 package com.ebikes.iam.services.users;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.ebikes.iam.constants.EventConstants.EventTypes;
 import com.ebikes.iam.constants.EventConstants.RoutingKeys;
 import com.ebikes.iam.database.entities.Membership;
@@ -24,20 +37,9 @@ import com.ebikes.iam.support.audit.AuditTemplate;
 import com.ebikes.iam.support.context.ExecutionContext;
 import com.ebikes.iam.support.database.FilterUtilities;
 import com.ebikes.iam.support.security.RBACUtilities;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/users/UserProvisioningService.java
+++ b/src/main/java/com/ebikes/iam/services/users/UserProvisioningService.java
@@ -1,5 +1,13 @@
 package com.ebikes.iam.services.users;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.ebikes.iam.configurations.properties.KeycloakProperties;
 import com.ebikes.iam.constants.ApplicationConstants;
 import com.ebikes.iam.constants.EventConstants.EventTypes;
@@ -20,15 +28,9 @@ import com.ebikes.iam.support.audit.AuditContext;
 import com.ebikes.iam.support.audit.AuditTemplate;
 import com.ebikes.iam.support.context.ExecutionContext;
 import com.ebikes.iam.support.security.RBACUtilities;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/services/verification/VerificationLinkBuilder.java
+++ b/src/main/java/com/ebikes/iam/services/verification/VerificationLinkBuilder.java
@@ -1,9 +1,11 @@
 package com.ebikes.iam.services.verification;
 
+import org.springframework.stereotype.Component;
+
 import com.ebikes.iam.configurations.properties.WebClientProperties;
+
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 @AllArgsConstructor
 @Component

--- a/src/main/java/com/ebikes/iam/services/verification/VerificationService.java
+++ b/src/main/java/com/ebikes/iam/services/verification/VerificationService.java
@@ -1,5 +1,11 @@
 package com.ebikes.iam.services.verification;
 
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.ebikes.iam.constants.EventConstants.EventTypes;
 import com.ebikes.iam.constants.EventConstants.RoutingKeys;
 import com.ebikes.iam.constants.MDCKeys;
@@ -20,13 +26,9 @@ import com.ebikes.iam.support.audit.AuditContext;
 import com.ebikes.iam.support.audit.AuditMetadataBuilder;
 import com.ebikes.iam.support.audit.AuditTemplate;
 import com.ebikes.iam.support.security.TokenHashUtilities;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/iam/support/audit/AuditMetadataBuilder.java
+++ b/src/main/java/com/ebikes/iam/support/audit/AuditMetadataBuilder.java
@@ -1,13 +1,14 @@
 package com.ebikes.iam.support.audit;
 
-import com.ebikes.iam.database.entities.Contact;
-import com.ebikes.iam.database.entities.Membership;
-import com.ebikes.iam.database.entities.UserExtension;
-import lombok.experimental.UtilityClass;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.ebikes.iam.database.entities.Contact;
+import com.ebikes.iam.database.entities.Membership;
+import com.ebikes.iam.database.entities.UserExtension;
+
+import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class AuditMetadataBuilder {

--- a/src/main/java/com/ebikes/iam/support/audit/AuditTemplate.java
+++ b/src/main/java/com/ebikes/iam/support/audit/AuditTemplate.java
@@ -1,14 +1,16 @@
 package com.ebikes.iam.support.audit;
 
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
 import com.ebikes.iam.constants.MDCKeys;
 import com.ebikes.iam.dtos.events.outgoing.AuditEvent;
 import com.ebikes.iam.enums.AuditOutcome;
 import com.ebikes.iam.publishers.AuditEventPublisher;
 import com.ebikes.iam.support.context.ExecutionContext;
+
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import org.slf4j.MDC;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/ebikes/iam/support/context/ExecutionContext.java
+++ b/src/main/java/com/ebikes/iam/support/context/ExecutionContext.java
@@ -1,10 +1,11 @@
 package com.ebikes.iam.support.context;
 
-import com.ebikes.iam.constants.ApplicationConstants;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.Collections;
 import java.util.Set;
+
+import com.ebikes.iam.constants.ApplicationConstants;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public final class ExecutionContext {

--- a/src/main/java/com/ebikes/iam/support/database/FilterUtilities.java
+++ b/src/main/java/com/ebikes/iam/support/database/FilterUtilities.java
@@ -1,17 +1,19 @@
 package com.ebikes.iam.support.database;
 
-import com.ebikes.iam.dtos.requests.filters.BaseFilter;
-import com.ebikes.iam.enums.ResponseCode;
-import com.ebikes.iam.exceptions.ValidationException;
-import lombok.experimental.UtilityClass;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.Set;
+
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.util.Set;
+import com.ebikes.iam.dtos.requests.filters.BaseFilter;
+import com.ebikes.iam.enums.ResponseCode;
+import com.ebikes.iam.exceptions.ValidationException;
+
+import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class FilterUtilities {

--- a/src/main/java/com/ebikes/iam/support/events/EventContextDecorator.java
+++ b/src/main/java/com/ebikes/iam/support/events/EventContextDecorator.java
@@ -1,11 +1,13 @@
 package com.ebikes.iam.support.events;
 
+import org.springframework.messaging.Message;
+
 import com.ebikes.iam.constants.EventConstants.EventSource;
 import com.ebikes.iam.constants.EventConstants.MessageHeaders;
 import com.ebikes.iam.support.context.EventContext;
 import com.ebikes.iam.support.context.ExecutionContext;
+
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.Message;
 
 @Slf4j
 public class EventContextDecorator {

--- a/src/main/java/com/ebikes/iam/support/keycloak/GroupPathUtilities.java
+++ b/src/main/java/com/ebikes/iam/support/keycloak/GroupPathUtilities.java
@@ -1,9 +1,10 @@
 package com.ebikes.iam.support.keycloak;
 
-import lombok.experimental.UtilityClass;
+import java.nio.charset.StandardCharsets;
+
 import org.springframework.util.DigestUtils;
 
-import java.nio.charset.StandardCharsets;
+import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class GroupPathUtilities {

--- a/src/main/java/com/ebikes/iam/support/keycloak/KeycloakResponseUtilities.java
+++ b/src/main/java/com/ebikes/iam/support/keycloak/KeycloakResponseUtilities.java
@@ -1,8 +1,8 @@
 package com.ebikes.iam.support.keycloak;
 
-import jakarta.ws.rs.core.Response;
-
 import java.net.URI;
+
+import jakarta.ws.rs.core.Response;
 
 public final class KeycloakResponseUtilities {
 

--- a/src/main/java/com/ebikes/iam/support/references/ReferenceGenerator.java
+++ b/src/main/java/com/ebikes/iam/support/references/ReferenceGenerator.java
@@ -1,11 +1,12 @@
 package com.ebikes.iam.support.references;
 
-import com.ebikes.iam.constants.ApplicationConstants;
-import org.apache.commons.lang3.RandomStringUtils;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+import com.ebikes.iam.constants.ApplicationConstants;
 
 public final class ReferenceGenerator {
 

--- a/src/main/java/com/ebikes/iam/support/security/RBACUtilities.java
+++ b/src/main/java/com/ebikes/iam/support/security/RBACUtilities.java
@@ -1,13 +1,14 @@
 package com.ebikes.iam.support.security;
 
-import com.ebikes.iam.enums.RoleScope;
-import com.ebikes.iam.enums.UserRole;
-import lombok.experimental.UtilityClass;
-
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.ebikes.iam.enums.RoleScope;
+import com.ebikes.iam.enums.UserRole;
+
+import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class RBACUtilities {

--- a/src/main/java/com/ebikes/iam/support/security/TokenHashUtilities.java
+++ b/src/main/java/com/ebikes/iam/support/security/TokenHashUtilities.java
@@ -1,10 +1,10 @@
 package com.ebikes.iam.support.security;
 
-import lombok.experimental.UtilityClass;
-
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+
+import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class TokenHashUtilities {

--- a/src/main/java/com/ebikes/iam/support/web/ErrorResponseBuilder.java
+++ b/src/main/java/com/ebikes/iam/support/web/ErrorResponseBuilder.java
@@ -1,17 +1,18 @@
 package com.ebikes.iam.support.web;
 
+import java.util.List;
+
+import org.slf4j.MDC;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
 import com.ebikes.iam.constants.ApplicationConstants;
 import com.ebikes.iam.constants.MDCKeys;
 import com.ebikes.iam.dtos.responses.api.ErrorResponse;
 import com.ebikes.iam.dtos.responses.api.ErrorResponse.ErrorDetail;
 import com.ebikes.iam.enums.ResponseCode;
 import com.ebikes.iam.support.references.ReferenceGenerator;
-import org.slf4j.MDC;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-
-import java.util.List;
 
 public final class ErrorResponseBuilder {
 

--- a/src/main/java/com/ebikes/iam/support/web/IpAddressUtilities.java
+++ b/src/main/java/com/ebikes/iam/support/web/IpAddressUtilities.java
@@ -1,6 +1,7 @@
 package com.ebikes.iam.support.web;
 
 import jakarta.servlet.http.HttpServletRequest;
+
 import lombok.experimental.UtilityClass;
 
 @UtilityClass


### PR DESCRIPTION
## Purpose
Adds Prometheus metrics instrumentation to the IAM service by including the Micrometer Prometheus registry. This enables Prometheus to scrape the `/actuator/prometheus` endpoint and makes IAM service health and performance visible in Grafana dashboards as part of the platform observability rollout.

## List of Changes
- Added `micrometer-registry-prometheus` dependency to `pom.xml`

## Linked Issues
N/A

## How to Test
1. Run the IAM service locally with `mvn spring-boot:run`
2. Send a GET request to `http://localhost:9085/actuator/prometheus`
3. Confirm a `200` response with Prometheus-format metrics output including JVM, HTTP, HikariCP, and RabbitMQ metrics

## Additional Information
No configuration changes were required. The `application.yml` already exposes the `prometheus` actuator endpoint:

```yaml
management:
  endpoints:
    web:
      exposure:
        include: health,info,metrics,prometheus
```

The actuator is served outside the servlet context path (`/ebikes-iam`) and is reachable directly at `/actuator/prometheus`.