### PR TITLE
chore(ci): update deployment command to use `ebikes-deploy-backend`

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -151,7 +151,7 @@ jobs:
               --instance-ids "${INSTANCE_ID}" \
               --document-name "AWS-RunShellScript" \
               --comment "Deploy iam sha-${SHORT_SHA}" \
-              --parameters commands="/usr/local/bin/ebikes-deploy-service deploy iam ${DEPLOYMENT_REFERENCE}" \
+              --parameters commands="/usr/local/bin/ebikes-deploy-backend deploy iam ${DEPLOYMENT_REFERENCE}" \
               --query 'Command.CommandId' \
               --output text
           )"

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -150,7 +150,7 @@ jobs:
               --instance-ids "${INSTANCE_ID}" \
               --document-name "AWS-RunShellScript" \
               --comment "Deploy iam sha-${SHORT_SHA}" \
-              --parameters commands="/usr/local/bin/ebikes-deploy-service deploy iam ${DEPLOYMENT_REFERENCE}" \
+              --parameters commands="/usr/local/bin/ebikes-deploy-backend deploy iam ${DEPLOYMENT_REFERENCE}" \
               --query 'Command.CommandId' \
               --output text
           )"

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -177,7 +177,7 @@ jobs:
               --instance-ids "${INSTANCE_ID}" \
               --document-name "AWS-RunShellScript" \
               --comment "Deploy iam sha-${SHORT_SHA}" \
-              --parameters commands="/usr/local/bin/ebikes-deploy-service deploy iam ${DEPLOYMENT_REFERENCE}" \
+              --parameters commands="/usr/local/bin/ebikes-deploy-backend deploy iam ${DEPLOYMENT_REFERENCE}" \
               --query 'Command.CommandId' \
               --output text
           )"


### PR DESCRIPTION
## Purpose
Corrects the SSM deployment command used in all three CI workflows to reference the current runner name `ebikes-deploy-backend`, replacing the stale `ebikes-deploy-service` command which no longer exists.

## List of Changes
- Updated `ebikes-deploy-service` to `ebikes-deploy-backend` in `.github/workflows/publish-dev.yml`
- Updated `ebikes-deploy-service` to `ebikes-deploy-backend` in `.github/workflows/publish-staging.yml`
- Updated `ebikes-deploy-service` to `ebikes-deploy-backend` in `.github/workflows/release-production.yml`

## Linked Issues
N/A

## How to Test
1. Trigger a deployment to any environment via the relevant workflow
2. Confirm the SSM command dispatches successfully without a `command not found` error
3. Confirm the IAM service deploys and converges on the target instance

## Additional Information
The runner was renamed from `ebikes-deploy-service` to `ebikes-deploy-backend` as part of the infrastructure script reorganisation. This change was not reflected in the CI workflows, causing all IAM deployments to fail at the SSM dispatch step.