### PR TITLE
chore(ci): add workflow dispatch trigger to enable manual deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'pom.xml'
       - 'Dockerfile'
       - '.github/workflows/ci.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Purpose

Adds `workflow_dispatch` to `ci.yml` to allow manual deployment triggers without requiring a file-touching commit on a protected branch.

## List of Changes

- `ci.yml` — add `workflow_dispatch` trigger

## How to Test

1. Go to **Actions → CI → Run workflow → select `dev`**
2. Confirm CI runs to completion
3. Confirm `publish-dev.yml` fires and deployment succeeds

## Additional Information
- N/A