### PR TITLE
feat(provisioning): implement system admin seed strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,17 +47,17 @@ RABBITMQ_CONSUMER_MAX_ATTEMPTS=3
 # =============================================================================
 # Keycloak
 # =============================================================================
-KEYCLOAK_URL=http://keycloak.localhost
+KEYCLOAK_URL=http://localhost:8080
 KEYCLOAK_REALM=ebikes
 KEYCLOAK_CLIENT_ID=ebikes-iam
 KEYCLOAK_CLIENT_SECRET=your-dev-keycloak-client-secret
-SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI=http://keycloak.localhost/realms/ebikes
-SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://keycloak.localhost/realms/ebikes/protocol/openid-connect/certs
+SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI=http://localhost:8080/realms/ebikes
+SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://localhost:8080/realms/ebikes/protocol/openid-connect/certs
 
 # =============================================================================
 # Contact expiry
 # =============================================================================
-CONTACT_EXPIRY_CRON=0 0 * * * *
+CONTACT_EXPIRY_CRON="0 0 * * * *"
 CONTACT_EXPIRY_HOURS=48
 CONTACT_STALE_THRESHOLD_HOURS=24
 
@@ -67,11 +67,21 @@ CONTACT_STALE_THRESHOLD_HOURS=24
 CLIENT_BASE_URL=http://localhost:3000
 
 # =============================================================================
+# Notifications
+# =============================================================================
+NOTIFICATIONS_ENABLED=true
+
+# =============================================================================
 # Organizations service
 # =============================================================================
 ORGANIZATION_SERVICE_BASE_URL=http://localhost:8083
 
 # =============================================================================
-# Notifications
+# seed configuration
 # =============================================================================
-NOTIFICATIONS_ENABLED=true
+SEED_SYSTEM_ADMIN_EMAIL=admin@ebikesafrica.co.ke
+SEED_SYSTEM_ADMIN_FIRST_NAME=System
+SEED_SYSTEM_ADMIN_LAST_NAME=Admin
+SEED_SYSTEM_ADMIN_PASSWORD=<your-string-password>
+SEED_SYSTEM_ADMIN_PHONE_NUMBER=+254700000000
+SEED_SYSTEM_ADMIN_USERNAME=system.admin

--- a/src/main/java/com/ebikes/iam/configurations/properties/SeedProperties.java
+++ b/src/main/java/com/ebikes/iam/configurations/properties/SeedProperties.java
@@ -1,0 +1,21 @@
+package com.ebikes.iam.configurations.properties;
+
+import jakarta.validation.constraints.NotBlank;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+@ConfigurationProperties(prefix = "seed.system-admin")
+@Component
+@Data
+public class SeedProperties {
+
+  @NotBlank private String email;
+  @NotBlank private String firstName;
+  @NotBlank private String lastName;
+  @NotBlank private String password;
+  @NotBlank private String phoneNumber;
+  @NotBlank private String username;
+}

--- a/src/main/java/com/ebikes/iam/constants/ApplicationConstants.java
+++ b/src/main/java/com/ebikes/iam/constants/ApplicationConstants.java
@@ -19,9 +19,9 @@ public final class ApplicationConstants {
   }
 
   public static final class Keycloak {
-    public static final String ACTIVE_BRANCH_ATTRIBUTE = "active_branch";
-    public static final String ACTIVE_ORGANIZATION_ATTRIBUTE = "active_organization";
-    public static final String ACTIVE_ORGANIZATION_ROLES_ATTRIBUTE = "active_organization_roles";
+    public static final String ACTIVE_BRANCH_ATTRIBUTE = "activeBranch";
+    public static final String ACTIVE_ORGANIZATION_ATTRIBUTE = "activeOrganization";
+    public static final String ACTIVE_ORGANIZATION_ROLES_ATTRIBUTE = "activeOrganizationRoles";
     public static final String PHONE_NUMBER_ATTRIBUTE = "phoneNumber";
     public static final String PHONE_NUMBER_VERIFIED_ATTRIBUTE = "phoneNumberVerified";
 

--- a/src/main/java/com/ebikes/iam/constants/EventConstants.java
+++ b/src/main/java/com/ebikes/iam/constants/EventConstants.java
@@ -77,7 +77,7 @@ public final class EventConstants {
 
       private Configuration() {}
 
-      public static final String REQUESTED = Source.IAM + ".user-extension.requested";
+      public static final String REQUESTED = Source.IAM + ".user-extension.configuration-requested";
     }
   }
 

--- a/src/main/java/com/ebikes/iam/database/specifications/OutboxSpecifications.java
+++ b/src/main/java/com/ebikes/iam/database/specifications/OutboxSpecifications.java
@@ -75,8 +75,7 @@ public class OutboxSpecifications {
   }
 
   public static Specification<Outbox> hasEventType(String eventType) {
-    return (root, query, criteriaBuilder) ->
-        criteriaBuilder.equal(root.get(FIELD_EVENT_TYPE), eventType);
+    return FilterUtilities.likeIgnoreCase(FIELD_EVENT_TYPE, eventType);
   }
 
   public static Specification<Outbox> hasMaxRetryCount(Integer maxRetryCount) {

--- a/src/main/java/com/ebikes/iam/seed/SystemAdminSeedService.java
+++ b/src/main/java/com/ebikes/iam/seed/SystemAdminSeedService.java
@@ -1,0 +1,112 @@
+package com.ebikes.iam.seed;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+
+import com.ebikes.iam.adapters.keycloak.KeycloakGroupAdapter;
+import com.ebikes.iam.adapters.keycloak.KeycloakUserAdapter;
+import com.ebikes.iam.configurations.properties.KeycloakProperties;
+import com.ebikes.iam.configurations.properties.SeedProperties;
+import com.ebikes.iam.constants.ApplicationConstants.Keycloak;
+import com.ebikes.iam.database.entities.UserExtension;
+import com.ebikes.iam.dtos.requests.memberships.CreateMembershipRequest;
+import com.ebikes.iam.dtos.requests.users.CreateUserRequest;
+import com.ebikes.iam.enums.UserRole;
+import com.ebikes.iam.services.users.UserExtensionService;
+import com.ebikes.iam.services.users.membership.MembershipService;
+import com.ebikes.iam.support.context.ExecutionContext;
+import com.ebikes.iam.support.keycloak.GroupPathUtilities;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class SystemAdminSeedService {
+
+  private final KeycloakGroupAdapter keycloakGroupAdapter;
+  private final KeycloakUserAdapter keycloakUserAdapter;
+  private final KeycloakProperties keycloakProperties;
+  private final MembershipService membershipService;
+  private final SeedProperties seedProperties;
+  private final UserExtensionService userExtensionService;
+
+  public void seedIfAbsent() {
+    if (keycloakUserAdapter.isEmailRegistered(seedProperties.getEmail())) {
+      log.info("System admin already exists - skipping seed");
+      return;
+    }
+
+    String organizationId = keycloakProperties.getBaseOrganizationId();
+    String groupPath = GroupPathUtilities.generate(organizationId);
+    String keycloakUserId = null;
+
+    try {
+      ExecutionContext.setSystem();
+
+      keycloakUserId =
+          keycloakUserAdapter.createUser(
+              seedProperties.getEmail(),
+              seedProperties.getFirstName(),
+              seedProperties.getLastName(),
+              seedProperties.getUsername());
+
+      Map<String, String> attributes = new HashMap<>();
+      attributes.put(Keycloak.ACTIVE_ORGANIZATION_ATTRIBUTE, organizationId);
+      attributes.put(Keycloak.ACTIVE_ORGANIZATION_ROLES_ATTRIBUTE, UserRole.SYSTEM_ADMIN.name());
+      attributes.put(Keycloak.PHONE_NUMBER_ATTRIBUTE, seedProperties.getPhoneNumber());
+      attributes.put(Keycloak.PHONE_NUMBER_VERIFIED_ATTRIBUTE, "false");
+      keycloakUserAdapter.updateUserAttributes(keycloakUserId, attributes);
+
+      keycloakUserAdapter.resetPassword(keycloakUserId, seedProperties.getPassword(), true);
+
+      keycloakGroupAdapter.addUserToGroup(groupPath, keycloakUserId);
+
+      CreateUserRequest userRequest =
+          new CreateUserRequest(
+              null,
+              "KE",
+              seedProperties.getEmail(),
+              seedProperties.getFirstName(),
+              true,
+              seedProperties.getLastName(),
+              organizationId,
+              seedProperties.getPhoneNumber(),
+              Set.of(UserRole.SYSTEM_ADMIN),
+              seedProperties.getUsername());
+
+      UserExtension extension =
+          userExtensionService.create(keycloakUserId, organizationId, userRequest);
+
+      keycloakUserAdapter.enableUser(keycloakUserId);
+      userExtensionService.activate(extension);
+
+      membershipService.createRecord(
+          keycloakUserId,
+          groupPath,
+          new CreateMembershipRequest(null, true, organizationId, Set.of(UserRole.SYSTEM_ADMIN)),
+          extension);
+
+      log.info("System admin seeded successfully - keycloakUserId={}", keycloakUserId);
+
+    } catch (Exception e) {
+      if (keycloakUserId != null) {
+        try {
+          keycloakUserAdapter.deleteUser(keycloakUserId);
+          log.warn(
+              "Compensated: Keycloak system admin deleted after seed failure - keycloakUserId={}",
+              keycloakUserId);
+        } catch (Exception ex) {
+          log.error("Compensation failed - keycloakUserId={} may be orphaned", keycloakUserId, ex);
+        }
+      }
+      throw e;
+    } finally {
+      ExecutionContext.clear();
+    }
+  }
+}

--- a/src/main/java/com/ebikes/iam/seed/runners/SystemAdminSeedRunner.java
+++ b/src/main/java/com/ebikes/iam/seed/runners/SystemAdminSeedRunner.java
@@ -1,0 +1,27 @@
+package com.ebikes.iam.seed.runners;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.ebikes.iam.seed.SystemAdminSeedService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Order(1)
+@RequiredArgsConstructor
+@Slf4j
+public class SystemAdminSeedRunner implements ApplicationRunner {
+
+  private final SystemAdminSeedService systemAdminSeedService;
+
+  @Override
+  public void run(@NonNull ApplicationArguments args) {
+    log.info("Running system admin seed check");
+    systemAdminSeedService.seedIfAbsent();
+  }
+}

--- a/src/main/java/com/ebikes/iam/services/users/UserExtensionService.java
+++ b/src/main/java/com/ebikes/iam/services/users/UserExtensionService.java
@@ -31,7 +31,6 @@ import com.ebikes.iam.enums.UserStatus;
 import com.ebikes.iam.exceptions.ResourceNotFoundException;
 import com.ebikes.iam.exceptions.ValidationException;
 import com.ebikes.iam.mappers.UserExtensionMapper;
-import com.ebikes.iam.services.notifications.NotificationService;
 import com.ebikes.iam.support.audit.AuditContext;
 import com.ebikes.iam.support.audit.AuditMetadataBuilder;
 import com.ebikes.iam.support.audit.AuditTemplate;
@@ -51,7 +50,6 @@ public class UserExtensionService {
 
   private final AuditTemplate auditTemplate;
   private final KeycloakUserAdapter keycloakUserAdapter;
-  private final NotificationService notificationService;
   private final UserExtensionMapper mapper;
   private final UserExtensionRepository repository;
 
@@ -77,26 +75,20 @@ public class UserExtensionService {
     UserExtension userExtension =
         auditTemplate.execute(
             auditContext,
-            () -> {
-              UserExtension extension =
-                  repository.save(
-                      UserExtension.builder()
-                          .branchId(request.branchId())
-                          .countryCode(request.countryCode())
-                          .email(request.email())
-                          .firstName(request.firstName())
-                          .keycloakUserId(keycloakUserId)
-                          .lastName(request.lastName())
-                          .organizationId(organizationId)
-                          .phoneNumber(request.phoneNumber())
-                          .status(UserStatus.INACTIVE)
-                          .username(request.username())
-                          .build());
-
-              notificationService.sendAccountVerification(organizationId, extension);
-
-              return extension;
-            },
+            () ->
+                repository.save(
+                    UserExtension.builder()
+                        .branchId(request.branchId())
+                        .countryCode(request.countryCode())
+                        .email(request.email())
+                        .firstName(request.firstName())
+                        .keycloakUserId(keycloakUserId)
+                        .lastName(request.lastName())
+                        .organizationId(organizationId)
+                        .phoneNumber(request.phoneNumber())
+                        .status(UserStatus.INACTIVE)
+                        .username(request.username())
+                        .build()),
             UserExtension::getId);
 
     log.info(
@@ -246,6 +238,7 @@ public class UserExtensionService {
 
   @Transactional(readOnly = true)
   public Page<UserExtensionSummaryResponse> search(UserExtensionFilter filter) {
+    log.debug("Filtering users by: {}", filter);
     Specification<UserExtension> spec = UserExtensionSpecifications.buildSpecification(filter);
     Pageable pageable =
         FilterUtilities.buildPageable(filter, UserExtensionSpecifications.ALLOWED_SORT_FIELDS);

--- a/src/main/java/com/ebikes/iam/services/users/provisioning/PersistenceService.java
+++ b/src/main/java/com/ebikes/iam/services/users/provisioning/PersistenceService.java
@@ -7,6 +7,7 @@ import com.ebikes.iam.database.entities.UserExtension;
 import com.ebikes.iam.dtos.requests.memberships.CreateMembershipRequest;
 import com.ebikes.iam.dtos.requests.users.CreateUserRequest;
 import com.ebikes.iam.publishers.UserConfigurationEventPublisher;
+import com.ebikes.iam.services.notifications.NotificationService;
 import com.ebikes.iam.services.users.UserExtensionService;
 import com.ebikes.iam.services.users.membership.MembershipService;
 
@@ -19,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PersistenceService {
 
   private final MembershipService membershipService;
+  private final NotificationService notificationService;
   private final UserConfigurationEventPublisher userConfigurationEventPublisher;
   private final UserExtensionService userExtensionService;
 
@@ -33,6 +35,7 @@ public class PersistenceService {
     UserExtension extension =
         userExtensionService.create(keycloakUserId, organizationId, userRequest);
     membershipService.createRecord(keycloakUserId, groupPath, membershipRequest, extension);
+    notificationService.sendAccountVerification(organizationId, extension);
     userConfigurationEventPublisher.publishRequest(extension, organizationId);
   }
 }

--- a/src/main/java/com/ebikes/iam/services/users/provisioning/ProvisioningService.java
+++ b/src/main/java/com/ebikes/iam/services/users/provisioning/ProvisioningService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 import com.ebikes.iam.adapters.keycloak.KeycloakGroupAdapter;
 import com.ebikes.iam.adapters.keycloak.KeycloakUserAdapter;
 import com.ebikes.iam.configurations.properties.KeycloakProperties;
-import com.ebikes.iam.constants.ApplicationConstants;
+import com.ebikes.iam.constants.ApplicationConstants.Keycloak;
 import com.ebikes.iam.dtos.requests.memberships.CreateMembershipRequest;
 import com.ebikes.iam.dtos.requests.users.CreateUserRequest;
 import com.ebikes.iam.dtos.requests.users.SignupRequest;
@@ -76,15 +76,13 @@ public class ProvisioningService {
             request.email(), request.firstName(), request.lastName(), request.username());
 
     Map<String, String> attributes = new HashMap<>();
-    attributes.put(
-        ApplicationConstants.Keycloak.ACTIVE_ORGANIZATION_ATTRIBUTE, context.organizationId());
-    attributes.put(
-        ApplicationConstants.Keycloak.ACTIVE_ORGANIZATION_ROLES_ATTRIBUTE, context.rolesCsv());
-    attributes.put(ApplicationConstants.Keycloak.PHONE_NUMBER_ATTRIBUTE, request.phoneNumber());
-    attributes.put(ApplicationConstants.Keycloak.PHONE_NUMBER_VERIFIED_ATTRIBUTE, "false");
+    attributes.put(Keycloak.ACTIVE_ORGANIZATION_ATTRIBUTE, context.organizationId());
+    attributes.put(Keycloak.ACTIVE_ORGANIZATION_ROLES_ATTRIBUTE, context.rolesCsv());
+    attributes.put(Keycloak.PHONE_NUMBER_ATTRIBUTE, request.phoneNumber());
+    attributes.put(Keycloak.PHONE_NUMBER_VERIFIED_ATTRIBUTE, "false");
 
     if (context.branchId() != null) {
-      attributes.put(ApplicationConstants.Keycloak.ACTIVE_BRANCH_ATTRIBUTE, context.branchId());
+      attributes.put(Keycloak.ACTIVE_BRANCH_ATTRIBUTE, context.branchId());
     }
 
     keycloakUserAdapter.updateUserAttributes(keycloakUserId, attributes);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,6 +69,10 @@ spring:
     parameters:
       searchPath: classpath:database/changelog/
 
+  mvc:
+    format:
+      date-time: iso
+
   rabbitmq:
     host: ${SPRING_RABBITMQ_HOST}
     port: ${SPRING_RABBITMQ_PORT}
@@ -155,6 +159,15 @@ security:
     - email
     - openid
     - profile
+
+seed:
+  system-admin:
+    email: ${SEED_SYSTEM_ADMIN_EMAIL}
+    first-name: ${SEED_SYSTEM_ADMIN_FIRST_NAME}
+    last-name: ${SEED_SYSTEM_ADMIN_LAST_NAME}
+    password: ${SEED_SYSTEM_ADMIN_PASSWORD}
+    phone-number: ${SEED_SYSTEM_ADMIN_PHONE_NUMBER}
+    username: ${SEED_SYSTEM_ADMIN_USERNAME}
 
 services:
   organizations:

--- a/src/test/java/com/ebikes/iam/services/users/UserExtensionServiceTest.java
+++ b/src/test/java/com/ebikes/iam/services/users/UserExtensionServiceTest.java
@@ -67,9 +67,7 @@ class UserExtensionServiceTest {
 
   @BeforeEach
   void setUp() {
-    service =
-        new UserExtensionService(
-            auditTemplate, keycloakUserAdapter, notificationService, mapper, repository);
+    service = new UserExtensionService(auditTemplate, keycloakUserAdapter, mapper, repository);
 
     ExecutionContext.set(
         UUID.randomUUID().toString(),
@@ -191,18 +189,6 @@ class UserExtensionServiceTest {
 
       assertThat(result).isEqualTo(saved);
       verify(repository).save(any(UserExtension.class));
-    }
-
-    @Test
-    @DisplayName("should send account verification notification after save")
-    void shouldSendAccountVerificationAfterSave() {
-      stubAuditSupplierWithExtractor();
-      UserExtension saved = UserExtensionFixtures.active(ORGANIZATION_ID);
-      when(repository.save(any())).thenReturn(saved);
-
-      service.create(KEYCLOAK_USER_ID, ORGANIZATION_ID, request());
-
-      verify(notificationService).sendAccountVerification(ORGANIZATION_ID, saved);
     }
   }
 


### PR DESCRIPTION
## Purpose

Decouples account verification notification from `UserExtensionService.create()` and lifts it to
`PersistenceService.persist()`, where it belongs as part of the provisioning flow. Also corrects
Keycloak custom attribute key names from snake_case to camelCase to align with the realm's
attribute mapper configuration.

## List of Changes

- `UserExtensionService`: removed `NotificationService` dependency; `create()` now purely
  persists and audits the user extension
- `PersistenceService`: added `NotificationService`; `persist()` now calls
  `sendAccountVerification()` after DB writes succeed
- `ApplicationConstants.Keycloak`: renamed attribute keys to camelCase (`activeOrganization`,
  `activeOrganizationRoles`, `activeBranch`) to match Keycloak realm mapper configuration
- `ProvisioningService`: updated to use static import of `ApplicationConstants.Keycloak`
- `OutboxSpecifications.hasEventType`: switched to `likeIgnoreCase` for consistency with other
  string filters
- `EventConstants`: corrected user configuration event type to
  `iam.user-extension.configuration-requested`
- `application.yaml`: added `spring.mvc.format.date-time: iso`; added `seed.system-admin` config block
- `.env.example`: added seed env vars; corrected Keycloak URLs to `localhost:8080`; added
  `NOTIFICATIONS_ENABLED`
- `UserExtensionServiceTest`: removed stale `notificationService` constructor arg

## Linked Issues

N/A

## How to Test

1. Run the application — verify seeded system admin receives no activation email on startup
2. Provision a new user via `POST /users` — verify activation email is still sent
3. Confirm `activeOrganizationRoles` attribute is populated correctly in Keycloak admin console
   after user provisioning

## Additional Information

New env vars added to `.env.example`:
- `SEED_SYSTEM_ADMIN_EMAIL`
- `SEED_SYSTEM_ADMIN_FIRST_NAME`
- `SEED_SYSTEM_ADMIN_LAST_NAME`
- `SEED_SYSTEM_ADMIN_PASSWORD`
- `SEED_SYSTEM_ADMIN_PHONE_NUMBER`
- `SEED_SYSTEM_ADMIN_USERNAME`

Keycloak attribute key rename is a breaking change if any existing users were provisioned with
the old snake_case keys — existing user attributes will need to be migrated manually in dev.