### PR TITLE
fix(tests): suppress seed runner in test contexts and add seed unit tests

### DIFF
--- a/src/main/java/com/ebikes/iam/seed/runners/SystemAdminSeedRunner.java
+++ b/src/main/java/com/ebikes/iam/seed/runners/SystemAdminSeedRunner.java
@@ -3,6 +3,7 @@ package com.ebikes.iam.seed.runners;
 import org.jspecify.annotations.NonNull;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Component
+@ConditionalOnProperty(name = "seed.enabled", havingValue = "true", matchIfMissing = true)
 @Order(1)
 @RequiredArgsConstructor
 @Slf4j

--- a/src/test/java/com/ebikes/iam/seed/SystemAdminSeedServiceTest.java
+++ b/src/test/java/com/ebikes/iam/seed/SystemAdminSeedServiceTest.java
@@ -1,0 +1,236 @@
+package com.ebikes.iam.seed;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ebikes.iam.adapters.keycloak.KeycloakGroupAdapter;
+import com.ebikes.iam.adapters.keycloak.KeycloakUserAdapter;
+import com.ebikes.iam.configurations.properties.KeycloakProperties;
+import com.ebikes.iam.configurations.properties.SeedProperties;
+import com.ebikes.iam.constants.ApplicationConstants;
+import com.ebikes.iam.database.entities.UserExtension;
+import com.ebikes.iam.dtos.requests.memberships.CreateMembershipRequest;
+import com.ebikes.iam.dtos.requests.users.CreateUserRequest;
+import com.ebikes.iam.services.users.UserExtensionService;
+import com.ebikes.iam.services.users.membership.MembershipService;
+import com.ebikes.iam.support.context.ExecutionContext;
+import com.ebikes.iam.support.fixtures.UserExtensionFixtures;
+
+import net.datafaker.Faker;
+
+@ExtendWith(MockitoExtension.class)
+class SystemAdminSeedServiceTest {
+
+  private static final Faker FAKER = new Faker();
+
+  @Mock private KeycloakGroupAdapter keycloakGroupAdapter;
+  @Mock private KeycloakUserAdapter keycloakUserAdapter;
+  @Mock private KeycloakProperties keycloakProperties;
+  @Mock private MembershipService membershipService;
+  @Mock private SeedProperties seedProperties;
+  @Mock private UserExtensionService userExtensionService;
+
+  @InjectMocks private SystemAdminSeedService service;
+
+  @AfterEach
+  void clearContext() {
+    ExecutionContext.clear();
+  }
+
+  @Nested
+  class WhenAdminAlreadyExists {
+
+    @BeforeEach
+    void setUp() {
+      when(seedProperties.getEmail()).thenReturn(FAKER.internet().emailAddress());
+      when(keycloakUserAdapter.isEmailRegistered(anyString())).thenReturn(true);
+    }
+
+    @Test
+    void seedIfAbsent_skipsAllProvisioning() {
+      service.seedIfAbsent();
+
+      verify(keycloakUserAdapter, never())
+          .createUser(anyString(), anyString(), anyString(), anyString());
+      verify(keycloakGroupAdapter, never()).addUserToGroup(anyString(), anyString());
+      verify(userExtensionService, never()).create(anyString(), anyString(), any());
+      verify(membershipService, never()).createRecord(anyString(), anyString(), any(), any());
+    }
+
+    @Test
+    void seedIfAbsent_leavesExecutionContextClear() {
+      service.seedIfAbsent();
+
+      assertThatThrownBy(ExecutionContext::get).isInstanceOf(IllegalStateException.class);
+    }
+  }
+
+  @Nested
+  class WhenAdminIsAbsent {
+
+    private static final String KEYCLOAK_USER_ID = "kc-" + ApplicationConstants.SYSTEM_ID;
+    private static final String ORGANIZATION_ID = ApplicationConstants.SYSTEM_ID;
+
+    private UserExtension extension;
+
+    @BeforeEach
+    void setUp() {
+      extension = UserExtensionFixtures.active();
+
+      when(seedProperties.getEmail()).thenReturn(FAKER.internet().emailAddress());
+      when(seedProperties.getFirstName()).thenReturn(FAKER.name().firstName());
+      when(seedProperties.getLastName()).thenReturn(FAKER.name().lastName());
+      when(seedProperties.getUsername()).thenReturn(FAKER.credentials().username());
+      when(seedProperties.getPassword()).thenReturn(FAKER.credentials().password());
+      when(seedProperties.getPhoneNumber()).thenReturn("+254" + FAKER.number().digits(9));
+
+      when(keycloakUserAdapter.isEmailRegistered(anyString())).thenReturn(false);
+      when(keycloakProperties.getBaseOrganizationId()).thenReturn(ORGANIZATION_ID);
+      when(keycloakUserAdapter.createUser(anyString(), anyString(), anyString(), anyString()))
+          .thenReturn(KEYCLOAK_USER_ID);
+      when(userExtensionService.create(anyString(), anyString(), any(CreateUserRequest.class)))
+          .thenReturn(extension);
+    }
+
+    @Test
+    void seedIfAbsent_createsKeycloakUser() {
+      service.seedIfAbsent();
+
+      verify(keycloakUserAdapter)
+          .createUser(
+              seedProperties.getEmail(),
+              seedProperties.getFirstName(),
+              seedProperties.getLastName(),
+              seedProperties.getUsername());
+    }
+
+    @Test
+    void seedIfAbsent_updatesAttributesAndResetsPassword() {
+      service.seedIfAbsent();
+
+      verify(keycloakUserAdapter).updateUserAttributes(eq(KEYCLOAK_USER_ID), anyMap());
+      verify(keycloakUserAdapter).resetPassword(eq(KEYCLOAK_USER_ID), anyString(), eq(true));
+    }
+
+    @Test
+    @DisplayName("creates user in base organization and adds to system admin group")
+    void seedIfAbsentAddsUserToGroup() {
+      service.seedIfAbsent();
+
+      verify(keycloakGroupAdapter).addUserToGroup(anyString(), eq(KEYCLOAK_USER_ID));
+    }
+
+    @Test
+    @DisplayName("creates user extension and activates it")
+    void seedIfAbsentCreatesExtensionAndActivates() {
+      service.seedIfAbsent();
+
+      verify(userExtensionService)
+          .create(eq(KEYCLOAK_USER_ID), eq(ORGANIZATION_ID), any(CreateUserRequest.class));
+      verify(keycloakUserAdapter).enableUser(KEYCLOAK_USER_ID);
+      verify(userExtensionService).activate(extension);
+    }
+
+    @Test
+    @DisplayName("creates membership record for system organization")
+    void seedIfAbsentCreatesMembershipRecord() {
+      service.seedIfAbsent();
+
+      verify(membershipService)
+          .createRecord(
+              eq(KEYCLOAK_USER_ID), anyString(), any(CreateMembershipRequest.class), eq(extension));
+    }
+
+    @Test
+    @DisplayName("clears execution context after successful provisioning")
+    void seedIfAbsentClearsExecutionContextAfterSuccess() {
+      service.seedIfAbsent();
+
+      assertThatThrownBy(ExecutionContext::get).isInstanceOf(IllegalStateException.class);
+    }
+  }
+
+  @Nested
+  class WhenSeedFails {
+
+    private static final String KEYCLOAK_USER_ID = "kc-" + ApplicationConstants.SYSTEM_ID;
+    private static final String ORGANIZATION_ID = ApplicationConstants.SYSTEM_ID;
+
+    @BeforeEach
+    void setUp() {
+      when(seedProperties.getEmail()).thenReturn(FAKER.internet().emailAddress());
+      when(keycloakUserAdapter.isEmailRegistered(anyString())).thenReturn(false);
+      when(keycloakProperties.getBaseOrganizationId()).thenReturn(ORGANIZATION_ID);
+    }
+
+    @Test
+    void seedIfAbsent_compensatesAndRethrows_whenFailureAfterUserCreated() {
+      when(seedProperties.getFirstName()).thenReturn(FAKER.name().firstName());
+      when(seedProperties.getLastName()).thenReturn(FAKER.name().lastName());
+      when(seedProperties.getUsername()).thenReturn(FAKER.credentials().username());
+      when(seedProperties.getPassword()).thenReturn(FAKER.credentials().password());
+      when(seedProperties.getPhoneNumber()).thenReturn("+254" + FAKER.number().digits(9));
+      when(keycloakUserAdapter.createUser(anyString(), anyString(), anyString(), anyString()))
+          .thenReturn(KEYCLOAK_USER_ID);
+      doThrow(new RuntimeException("group error"))
+          .when(keycloakGroupAdapter)
+          .addUserToGroup(anyString(), anyString());
+
+      Runnable call = service::seedIfAbsent;
+      assertThatThrownBy(call::run).isInstanceOf(RuntimeException.class);
+
+      verify(keycloakUserAdapter).deleteUser(KEYCLOAK_USER_ID);
+    }
+
+    @Test
+    void seedIfAbsent_skipsCompensation_whenFailureBeforeUserCreated() {
+      when(seedProperties.getFirstName()).thenReturn(FAKER.name().firstName());
+      when(seedProperties.getLastName()).thenReturn(FAKER.name().lastName());
+      when(seedProperties.getUsername()).thenReturn(FAKER.credentials().username());
+      doThrow(new RuntimeException("create error"))
+          .when(keycloakUserAdapter)
+          .createUser(anyString(), anyString(), anyString(), anyString());
+
+      Runnable call = service::seedIfAbsent;
+      assertThatThrownBy(call::run).isInstanceOf(RuntimeException.class);
+
+      verify(keycloakUserAdapter, never()).deleteUser(anyString());
+    }
+
+    @Test
+    void seedIfAbsent_clearsExecutionContextAfterFailure() {
+      doThrow(new RuntimeException("fail"))
+          .when(keycloakUserAdapter)
+          .createUser(anyString(), anyString(), anyString(), anyString());
+
+      when(seedProperties.getFirstName()).thenReturn(FAKER.name().firstName());
+      when(seedProperties.getLastName()).thenReturn(FAKER.name().lastName());
+      when(seedProperties.getUsername()).thenReturn(FAKER.credentials().username());
+
+      try {
+        service.seedIfAbsent();
+      } catch (Exception ignored) {
+        // exception is expected
+      }
+
+      assertThatThrownBy(ExecutionContext::get).isInstanceOf(IllegalStateException.class);
+    }
+  }
+}

--- a/src/test/java/com/ebikes/iam/seed/runners/SystemAdminSeedRunnerTest.java
+++ b/src/test/java/com/ebikes/iam/seed/runners/SystemAdminSeedRunnerTest.java
@@ -1,0 +1,30 @@
+package com.ebikes.iam.seed.runners;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.ApplicationArguments;
+
+import com.ebikes.iam.seed.SystemAdminSeedService;
+
+@ExtendWith(MockitoExtension.class)
+class SystemAdminSeedRunnerTest {
+
+  @Mock private SystemAdminSeedService systemAdminSeedService;
+  @Mock private ApplicationArguments args;
+
+  @InjectMocks private SystemAdminSeedRunner runner;
+
+  @Test
+  @DisplayName("should delegate to SystemAdminSeedService to seed system admin if absent")
+  void runDelegatesToSeedService() {
+    runner.run(args);
+
+    verify(systemAdminSeedService).seedIfAbsent();
+  }
+}

--- a/src/test/java/com/ebikes/iam/support/infrastructure/MockKeycloakConfig.java
+++ b/src/test/java/com/ebikes/iam/support/infrastructure/MockKeycloakConfig.java
@@ -1,6 +1,11 @@
 package com.ebikes.iam.support.infrastructure;
 
+import java.util.List;
+
 import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.representations.idm.UserRepresentation;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -12,6 +17,16 @@ public class MockKeycloakConfig {
   @Bean
   @Primary
   public Keycloak keycloakAdminClient() {
-    return Mockito.mock(Keycloak.class);
+    UsersResource usersResource = Mockito.mock(UsersResource.class);
+    Mockito.when(usersResource.searchByEmail(Mockito.anyString(), Mockito.eq(true)))
+        .thenReturn(List.of(new UserRepresentation()));
+
+    RealmResource realmResource = Mockito.mock(RealmResource.class);
+    Mockito.when(realmResource.users()).thenReturn(usersResource);
+
+    Keycloak keycloak = Mockito.mock(Keycloak.class);
+    Mockito.when(keycloak.realm(Mockito.anyString())).thenReturn(realmResource);
+
+    return keycloak;
   }
 }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -167,6 +167,16 @@ security:
     - openid
     - profile
 
+seed:
+  enabled: false
+  system-admin:
+    email: seed@test.local
+    first-name: Seed
+    last-name: Admin
+    password: SeedPass123!
+    phone-number: "+254700000000"
+    username: seed-admin
+
 services:
   organizations:
     base-url: http://localhost:0


### PR DESCRIPTION
## Purpose

Stabilises the integration test suite following the introduction of the system admin seed feature (#19). The `SystemAdminSeedRunner` was firing on every Spring context load during tests, causing NPEs in the Keycloak adapter chain. This PR suppresses seeding in test contexts, hardens the Keycloak mock, and adds unit test coverage for the seed components.

## List of Changes

- Added `@ConditionalOnProperty(name = "seed.enabled", havingValue = "true", matchIfMissing = true)` to `SystemAdminSeedRunner` so the runner does not register as a bean when `seed.enabled=false`
- Set `seed.enabled: false` in `application-test.yaml` and added placeholder `seed.system-admin.*` values to satisfy `@NotBlank` constraints on `SeedProperties`
- Stubbed the full `Keycloak → RealmResource → UsersResource` chain in `MockKeycloakConfig`, returning a non-empty user list so `isEmailRegistered` short-circuits to `true` as a safe fallback for any context where seeding is not suppressed
- Added `SystemAdminSeedRunnerTest` — verifies `seedIfAbsent()` is delegated to on `run()`
- Added `SystemAdminSeedServiceTest` — covers: early return when admin exists, full happy-path provisioning sequence, compensation (Keycloak user deletion) on failure after user creation, no compensation when failure occurs before user creation, and `ExecutionContext` cleanup in both success and failure paths

## Linked Issues

- Fixes context load failures introduced by #19

## How to Test

1. Run the full integration test suite: `mvn verify -P integration-test`
2. Confirm `VerificationServiceIT` and `OrganizationCacheServiceIT` pass without `ApplicationContext` failure errors
3. Run unit tests: `mvn test`
4. Confirm `SystemAdminSeedRunnerTest` and `SystemAdminSeedServiceTest` pass

## Additional Information

- `matchIfMissing = true` on the conditional ensures production behaviour is unchanged — `seed.enabled` is absent from `application.yaml` so the runner fires as before
- The `MockKeycloakConfig` stub is retained as a safety net for any future integration test contexts that do not set `seed.enabled=false`