### PR TITLE
feat(iam): inter-service OAuth2, membership enrichment, and authorization hardening

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,11 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
 

--- a/spotbugs/exclude-filter.xml
+++ b/spotbugs/exclude-filter.xml
@@ -109,4 +109,16 @@
         <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
     </Match>
 
+    <!--
+      EI_EXPOSE_REP2: false positive on Spring-managed collaborator injection.
+
+      SpotBugs flags storing an injected RestClient by reference as representation
+      exposure. RestClient is a Spring-managed interface with no externally mutable
+      state — defensive copying is neither meaningful nor possible for interface types.
+    -->
+    <Match>
+        <Class name="com.ebikes.iam.adapters.organizations.OrganizationServiceAdapter"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+
 </FindBugsFilter>

--- a/src/main/java/com/ebikes/iam/adapters/organizations/OrganizationServiceAdapter.java
+++ b/src/main/java/com/ebikes/iam/adapters/organizations/OrganizationServiceAdapter.java
@@ -3,12 +3,13 @@ package com.ebikes.iam.adapters.organizations;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
-import com.ebikes.iam.configurations.properties.OrganizationServiceProperties;
 import com.ebikes.iam.dtos.adapters.organizations.Branch;
 import com.ebikes.iam.dtos.adapters.organizations.Organization;
 import com.ebikes.iam.dtos.responses.api.SuccessResponse;
@@ -28,12 +29,8 @@ public class OrganizationServiceAdapter {
   private final RestClient restClient;
 
   public OrganizationServiceAdapter(
-      RestClient.Builder restClientBuilder, OrganizationServiceProperties properties) {
-    this.restClient =
-        restClientBuilder
-            .baseUrl(properties.getBaseUrl())
-            .defaultHeader("Content-Type", "application/json")
-            .build();
+      @Qualifier("organizationServiceRestClient") RestClient restClient) {
+    this.restClient = restClient;
   }
 
   public List<Organization> findOrganizationsByIds(Set<String> organizationIds) {
@@ -42,9 +39,13 @@ public class OrganizationServiceAdapter {
     try {
       SuccessResponse<List<Organization>> response =
           restClient
-              .post()
-              .uri(ORGANIZATIONS_REFERENCE_ENDPOINT)
-              .body(organizationIds)
+              .get()
+              .uri(
+                  uriBuilder ->
+                      uriBuilder
+                          .path(ORGANIZATIONS_REFERENCE_ENDPOINT)
+                          .queryParam("ids", organizationIds)
+                          .build())
               .retrieve()
               .body(new ParameterizedTypeReference<>() {});
 
@@ -74,9 +75,13 @@ public class OrganizationServiceAdapter {
     try {
       SuccessResponse<List<Branch>> response =
           restClient
-              .post()
-              .uri(BRANCHES_REFERENCE_ENDPOINT, organizationId)
-              .body(branchIds)
+              .get()
+              .uri(
+                  uriBuilder ->
+                      uriBuilder
+                          .path(BRANCHES_REFERENCE_ENDPOINT)
+                          .queryParam("ids", branchIds)
+                          .build(organizationId))
               .retrieve()
               .body(new ParameterizedTypeReference<>() {});
 
@@ -104,7 +109,7 @@ public class OrganizationServiceAdapter {
   }
 
   private int extractStatus(RestClientException e) {
-    if (e instanceof org.springframework.web.client.HttpStatusCodeException statusEx) {
+    if (e instanceof HttpStatusCodeException statusEx) {
       return statusEx.getStatusCode().value();
     }
     return 500;

--- a/src/main/java/com/ebikes/iam/configurations/RestClientConfiguration.java
+++ b/src/main/java/com/ebikes/iam/configurations/RestClientConfiguration.java
@@ -1,0 +1,39 @@
+package com.ebikes.iam.configurations;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.web.client.OAuth2ClientHttpRequestInterceptor;
+import org.springframework.security.oauth2.client.web.client.RequestAttributePrincipalResolver;
+import org.springframework.web.client.RestClient;
+
+import com.ebikes.iam.configurations.properties.OrganizationServiceProperties;
+
+@Configuration
+public class RestClientConfiguration {
+
+  @Bean
+  public RestClient organizationServiceRestClient(
+      RestClient.Builder restClientBuilder,
+      OAuth2AuthorizedClientManager authorizedClientManager,
+      OAuth2AuthorizedClientService authorizedClientService,
+      OrganizationServiceProperties organizationServiceProperties) {
+
+    OAuth2ClientHttpRequestInterceptor requestInterceptor =
+        new OAuth2ClientHttpRequestInterceptor(authorizedClientManager);
+
+    requestInterceptor.setAuthorizationFailureHandler(
+        OAuth2ClientHttpRequestInterceptor.authorizationFailureHandler(authorizedClientService));
+
+    requestInterceptor.setClientRegistrationIdResolver(
+        request -> organizationServiceProperties.getClientRegistrationId());
+
+    requestInterceptor.setPrincipalResolver(new RequestAttributePrincipalResolver());
+
+    return restClientBuilder
+        .baseUrl(organizationServiceProperties.getBaseUrl())
+        .requestInterceptor(requestInterceptor)
+        .build();
+  }
+}

--- a/src/main/java/com/ebikes/iam/configurations/properties/OrganizationServiceProperties.java
+++ b/src/main/java/com/ebikes/iam/configurations/properties/OrganizationServiceProperties.java
@@ -11,6 +11,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class OrganizationServiceProperties {
-
   private String baseUrl;
+  private String clientRegistrationId;
 }

--- a/src/main/java/com/ebikes/iam/configurations/security/SecurityConfiguration.java
+++ b/src/main/java/com/ebikes/iam/configurations/security/SecurityConfiguration.java
@@ -43,11 +43,6 @@ public class SecurityConfiguration {
   private final SecurityProperties securityProperties;
 
   @Bean
-  public ContextFilter contextFilter() {
-    return new ContextFilter();
-  }
-
-  @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtDecoder decoder) {
     return http.csrf(AbstractHttpConfigurer::disable)
         .cors(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/ebikes/iam/database/entities/UserExtension.java
+++ b/src/main/java/com/ebikes/iam/database/entities/UserExtension.java
@@ -1,6 +1,5 @@
 package com.ebikes.iam.database.entities;
 
-import java.io.Serial;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -59,8 +58,6 @@ import lombok.experimental.SuperBuilder;
           columnNames = {"phone_number"})
     })
 public class UserExtension extends SoftDeletableEntity {
-
-  @Serial private static final long serialVersionUID = 1L;
 
   @Column(name = "branch_id")
   private String branchId;

--- a/src/main/java/com/ebikes/iam/mappers/UserExtensionMapper.java
+++ b/src/main/java/com/ebikes/iam/mappers/UserExtensionMapper.java
@@ -7,8 +7,8 @@ import org.mapstruct.Mapping;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.ReportingPolicy;
 
-import com.ebikes.iam.database.entities.Membership;
 import com.ebikes.iam.database.entities.UserExtension;
+import com.ebikes.iam.dtos.responses.memberships.MembershipResponse;
 import com.ebikes.iam.dtos.responses.users.UserExtensionDetailResponse;
 import com.ebikes.iam.dtos.responses.users.UserExtensionSummaryResponse;
 import com.ebikes.iam.dtos.responses.users.UserProfileResponse;
@@ -16,8 +16,7 @@ import com.ebikes.iam.dtos.responses.users.UserProfileResponse;
 @Mapper(
     componentModel = "spring",
     nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
-    unmappedTargetPolicy = ReportingPolicy.IGNORE,
-    uses = {MembershipMapper.class})
+    unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface UserExtensionMapper {
 
   UserExtensionDetailResponse toDetailResponse(UserExtension userExtension);
@@ -29,5 +28,7 @@ public interface UserExtensionMapper {
   @Mapping(target = "id", source = "userExtension.id")
   @Mapping(target = "memberships", source = "memberships")
   UserProfileResponse toProfileResponse(
-      UserExtension userExtension, Membership activeMembership, List<Membership> memberships);
+      UserExtension userExtension,
+      MembershipResponse activeMembership,
+      List<MembershipResponse> memberships);
 }

--- a/src/main/java/com/ebikes/iam/services/users/UserExtensionService.java
+++ b/src/main/java/com/ebikes/iam/services/users/UserExtensionService.java
@@ -23,6 +23,7 @@ import com.ebikes.iam.database.specifications.UserExtensionSpecifications;
 import com.ebikes.iam.dtos.requests.filters.UserExtensionFilter;
 import com.ebikes.iam.dtos.requests.users.CreateUserRequest;
 import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
+import com.ebikes.iam.dtos.responses.memberships.MembershipResponse;
 import com.ebikes.iam.dtos.responses.users.UserExtensionDetailResponse;
 import com.ebikes.iam.dtos.responses.users.UserExtensionSummaryResponse;
 import com.ebikes.iam.dtos.responses.users.UserProfileResponse;
@@ -30,6 +31,7 @@ import com.ebikes.iam.enums.ResponseCode;
 import com.ebikes.iam.enums.UserStatus;
 import com.ebikes.iam.exceptions.ResourceNotFoundException;
 import com.ebikes.iam.exceptions.ValidationException;
+import com.ebikes.iam.mappers.MembershipEnricher;
 import com.ebikes.iam.mappers.UserExtensionMapper;
 import com.ebikes.iam.support.audit.AuditContext;
 import com.ebikes.iam.support.audit.AuditMetadataBuilder;
@@ -50,6 +52,7 @@ public class UserExtensionService {
 
   private final AuditTemplate auditTemplate;
   private final KeycloakUserAdapter keycloakUserAdapter;
+  private final MembershipEnricher membershipEnricher;
   private final UserExtensionMapper mapper;
   private final UserExtensionRepository repository;
 
@@ -201,11 +204,16 @@ public class UserExtensionService {
                     new ResourceNotFoundException(
                         ResponseCode.RESOURCE_NOT_FOUND, "User not found"));
 
-    Membership activeMembership =
+    List<MembershipResponse> enrichedMemberships =
+        membershipEnricher.enrich(List.copyOf(user.getMemberships()));
+
+    MembershipResponse activeMembership =
         findActiveMembership(user.getMemberships(), ctx.activeOrganization(), ctx.activeBranch())
+            .flatMap(
+                m -> enrichedMemberships.stream().filter(r -> r.id().equals(m.getId())).findFirst())
             .orElseThrow(() -> new IllegalStateException("No active membership found for user"));
 
-    return mapper.toProfileResponse(user, activeMembership, List.copyOf(user.getMemberships()));
+    return mapper.toProfileResponse(user, activeMembership, enrichedMemberships);
   }
 
   @Transactional

--- a/src/main/java/com/ebikes/iam/services/users/provisioning/AuthorizationService.java
+++ b/src/main/java/com/ebikes/iam/services/users/provisioning/AuthorizationService.java
@@ -33,6 +33,11 @@ public class AuthorizationService {
       return;
     }
 
+    if (ExecutionContext.get() instanceof ExecutionContext.UserContext uc
+        && uc.roles().contains(UserRole.SYSTEM_ADMIN.name())) {
+      return;
+    }
+
     String creatorBranchId = ctx.activeBranch();
 
     Membership creatorMembership =

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -80,6 +80,17 @@ spring:
 
   security:
     oauth2:
+      client:
+        registration:
+          organizations:
+            provider: keycloak
+            client-id: ${IAM_CLIENT_ID}
+            client-secret: ${IAM_CLIENT_SECRET}
+            authorization-grant-type: client_credentials
+            client-authentication-method: client_secret_basic
+        provider:
+          keycloak:
+            issuer-uri: ${SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI}
       resourceserver:
         jwt:
           issuer-uri: ${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI}
@@ -113,8 +124,8 @@ contact:
   stale-threshold-hours: ${CONTACT_STALE_THRESHOLD_HOURS}
 
 keycloak:
-  client-id: ${KEYCLOAK_CLIENT_ID}
-  client-secret: ${KEYCLOAK_CLIENT_SECRET}
+  client-id: ${IAM_CLIENT_ID}
+  client-secret: ${IAM_CLIENT_SECRET}
   realm: ${KEYCLOAK_REALM}
   url: ${KEYCLOAK_URL}
   web-client-id: ${KEYCLOAK_WEB_CLIENT_ID}
@@ -172,6 +183,7 @@ seed:
 services:
   organizations:
     base-url: ${ORGANIZATION_SERVICE_BASE_URL}
+    client-registration-id: organizations
 
 token:
   account-activation:

--- a/src/test/java/com/ebikes/iam/adapters/organizations/OrganizationServiceAdapterTest.java
+++ b/src/test/java/com/ebikes/iam/adapters/organizations/OrganizationServiceAdapterTest.java
@@ -3,12 +3,12 @@ package com.ebikes.iam.adapters.organizations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,7 +23,6 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
-import com.ebikes.iam.configurations.properties.OrganizationServiceProperties;
 import com.ebikes.iam.dtos.adapters.organizations.Branch;
 import com.ebikes.iam.dtos.adapters.organizations.Organization;
 import com.ebikes.iam.dtos.responses.api.SuccessResponse;
@@ -36,42 +35,31 @@ class OrganizationServiceAdapterTest {
   private static final String ORGANIZATION_ID = "org-1";
   private static final String BRANCH_ID = "branch-1";
 
-  @Mock private RestClient.Builder restClientBuilder;
   @Mock private RestClient restClient;
-  @Mock private OrganizationServiceProperties properties;
 
   private OrganizationServiceAdapter adapter;
 
   private RestClient.ResponseSpec responseSpec;
-  private RestClient.RequestBodyUriSpec requestBodyUriSpec;
-  private RestClient.RequestBodySpec requestBodySpec;
 
   @BeforeEach
+  @SuppressWarnings("unchecked")
   void setUp() {
-    when(properties.getBaseUrl()).thenReturn("http://localhost:8080");
-    when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
-    when(restClientBuilder.defaultHeader(anyString(), anyString())).thenReturn(restClientBuilder);
-    when(restClientBuilder.build()).thenReturn(restClient);
+    adapter = new OrganizationServiceAdapter(restClient);
 
-    adapter = new OrganizationServiceAdapter(restClientBuilder, properties);
-
-    requestBodyUriSpec = mock(RestClient.RequestBodyUriSpec.class);
-    requestBodySpec = mock(RestClient.RequestBodySpec.class);
+    @SuppressWarnings("rawtypes")
+    RestClient.RequestHeadersUriSpec requestHeadersUriSpec =
+        mock(RestClient.RequestHeadersUriSpec.class);
+    RestClient.RequestHeadersSpec<?> requestHeadersSpec = mock(RestClient.RequestHeadersSpec.class);
     responseSpec = mock(RestClient.ResponseSpec.class);
 
-    when(restClient.post()).thenReturn(requestBodyUriSpec);
-    when(requestBodySpec.body(any(Object.class))).thenReturn(requestBodySpec);
-    when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+    when(restClient.get()).thenReturn(requestHeadersUriSpec);
+    when(requestHeadersUriSpec.uri(any(Function.class))).thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
   }
 
   @Nested
   @DisplayName("findOrganizationsByIds")
   class FindOrganizationsByIds {
-
-    @BeforeEach
-    void setUp() {
-      when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
-    }
 
     @Test
     @DisplayName("should return organisations from successful response")
@@ -138,11 +126,6 @@ class OrganizationServiceAdapterTest {
   @Nested
   @DisplayName("findBranchesByIds")
   class FindBranchesByIds {
-
-    @BeforeEach
-    void setUp() {
-      when(requestBodyUriSpec.uri(anyString(), (Object[]) any())).thenReturn(requestBodySpec);
-    }
 
     @Test
     @DisplayName("should return branches from successful response")

--- a/src/test/java/com/ebikes/iam/controllers/UserControllerTest.java
+++ b/src/test/java/com/ebikes/iam/controllers/UserControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.ebikes.iam.services.users.UserExtensionService;
 import com.ebikes.iam.services.users.provisioning.ProvisioningService;
+import com.ebikes.iam.support.fixtures.SecurityFixtures;
 import com.ebikes.iam.support.fixtures.UserExtensionResponseFixtures;
 import com.ebikes.iam.support.fixtures.UserRequestFixtures;
 import com.ebikes.iam.support.infrastructure.AbstractControllerTest;
@@ -49,7 +50,7 @@ class UserControllerTest extends AbstractControllerTest {
       mockMvc
           .perform(
               post("/users")
-                  .with(authenticatedJwt())
+                  .with(SecurityFixtures.authenticatedJwt())
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(objectMapper.writeValueAsString(UserRequestFixtures.createUser())))
           .andExpect(status().isCreated());
@@ -63,20 +64,11 @@ class UserControllerTest extends AbstractControllerTest {
       mockMvc
           .perform(
               post("/users")
-                  .with(authenticatedJwt())
+                  .with(SecurityFixtures.authenticatedJwt())
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(
-                      """
-                      {
-                        "countryCode": "KE",
-                        "email": "",
-                        "firstName": "John",
-                        "lastName": "Doe",
-                        "phoneNumber": "+254700000001",
-                        "roles": ["CUSTOMER"],
-                        "username": "johndoe"
-                      }
-                      """))
+                      objectMapper.writeValueAsString(
+                          UserRequestFixtures.createUserWithBlankEmail())))
           .andExpect(status().isBadRequest());
     }
 
@@ -86,20 +78,11 @@ class UserControllerTest extends AbstractControllerTest {
       mockMvc
           .perform(
               post("/users")
-                  .with(authenticatedJwt())
+                  .with(SecurityFixtures.authenticatedJwt())
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(
-                      """
-                      {
-                        "countryCode": "KE",
-                        "email": "test@ebikes.test",
-                        "firstName": "John",
-                        "lastName": "Doe",
-                        "phoneNumber": "+254700000001",
-                        "roles": [],
-                        "username": "johndoe"
-                      }
-                      """))
+                      objectMapper.writeValueAsString(
+                          UserRequestFixtures.createUserWithEmptyRoles())))
           .andExpect(status().isBadRequest());
     }
 
@@ -143,16 +126,7 @@ class UserControllerTest extends AbstractControllerTest {
                   .with(anonymous())
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(
-                      """
-                      {
-                        "countryCode": "KE",
-                        "email": "",
-                        "firstName": "John",
-                        "lastName": "Doe",
-                        "phoneNumber": "+254700000001",
-                        "username": "johndoe"
-                      }
-                      """))
+                      objectMapper.writeValueAsString(UserRequestFixtures.signupWithBlankEmail())))
           .andExpect(status().isBadRequest());
     }
 
@@ -165,16 +139,8 @@ class UserControllerTest extends AbstractControllerTest {
                   .with(anonymous())
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(
-                      """
-                      {
-                        "countryCode": "KE",
-                        "email": "test@ebikes.test",
-                        "firstName": "John",
-                        "lastName": "Doe",
-                        "phoneNumber": "",
-                        "username": "johndoe"
-                      }
-                      """))
+                      objectMapper.writeValueAsString(
+                          UserRequestFixtures.signupWithBlankPhoneNumber())))
           .andExpect(status().isBadRequest());
     }
 
@@ -201,7 +167,7 @@ class UserControllerTest extends AbstractControllerTest {
       when(userExtensionService.findById(any())).thenReturn(UserExtensionResponseFixtures.detail());
 
       mockMvc
-          .perform(get("/users/{id}", UUID.randomUUID()).with(authenticatedJwt()))
+          .perform(get("/users/{id}", UUID.randomUUID()).with(SecurityFixtures.authenticatedJwt()))
           .andExpect(status().isOk());
 
       verify(userExtensionService).findById(any());
@@ -225,7 +191,9 @@ class UserControllerTest extends AbstractControllerTest {
     void shouldReturn200WithUserProfile() throws Exception {
       when(userExtensionService.me()).thenReturn(UserExtensionResponseFixtures.profile());
 
-      mockMvc.perform(get("/users/me").with(authenticatedJwt())).andExpect(status().isOk());
+      mockMvc
+          .perform(get("/users/me").with(SecurityFixtures.authenticatedJwt()))
+          .andExpect(status().isOk());
 
       verify(userExtensionService).me();
     }
@@ -246,7 +214,9 @@ class UserControllerTest extends AbstractControllerTest {
     void shouldReturn200WithPaginatedResults() throws Exception {
       when(userExtensionService.search(any())).thenReturn(Page.empty());
 
-      mockMvc.perform(get("/users").with(authenticatedJwt())).andExpect(status().isOk());
+      mockMvc
+          .perform(get("/users").with(SecurityFixtures.authenticatedJwt()))
+          .andExpect(status().isOk());
 
       verify(userExtensionService).search(any());
     }
@@ -271,17 +241,9 @@ class UserControllerTest extends AbstractControllerTest {
       mockMvc
           .perform(
               put("/users/{id}", UUID.randomUUID())
-                  .with(authenticatedJwt())
+                  .with(SecurityFixtures.authenticatedJwt())
                   .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                      {
-                        "firstName": "Updated",
-                        "lastName": "Name",
-                        "emailVerified": false,
-                        "phoneNumberVerified": false
-                      }
-                      """))
+                  .content(objectMapper.writeValueAsString(UserRequestFixtures.updateUser())))
           .andExpect(status().isOk());
 
       verify(userExtensionService).update(any(), any());
@@ -295,14 +257,7 @@ class UserControllerTest extends AbstractControllerTest {
               put("/users/{id}", UUID.randomUUID())
                   .with(anonymous())
                   .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                      {
-                        "firstName": "Updated",
-                        "emailVerified": false,
-                        "phoneNumberVerified": false
-                      }
-                      """))
+                  .content(objectMapper.writeValueAsString(UserRequestFixtures.updateUser())))
           .andExpect(status().isUnauthorized());
     }
   }
@@ -317,7 +272,7 @@ class UserControllerTest extends AbstractControllerTest {
       mockMvc
           .perform(
               put("/users/{id}/status", UUID.randomUUID())
-                  .with(authenticatedJwt())
+                  .with(SecurityFixtures.authenticatedJwt())
                   .param("status", "ACTIVE"))
           .andExpect(status().isOk());
 
@@ -344,7 +299,8 @@ class UserControllerTest extends AbstractControllerTest {
     @DisplayName("should return 200 when user exists")
     void shouldReturn200WhenUserExists() throws Exception {
       mockMvc
-          .perform(delete("/users/{id}", UUID.randomUUID()).with(authenticatedJwt()))
+          .perform(
+              delete("/users/{id}", UUID.randomUUID()).with(SecurityFixtures.authenticatedJwt()))
           .andExpect(status().isOk());
 
       verify(userExtensionService).delete(any());
@@ -367,7 +323,9 @@ class UserControllerTest extends AbstractControllerTest {
     @DisplayName("should return 200 when user exists")
     void shouldReturn200WhenUserExists() throws Exception {
       mockMvc
-          .perform(delete("/users/{id}/deprovision", UUID.randomUUID()).with(authenticatedJwt()))
+          .perform(
+              delete("/users/{id}/deprovision", UUID.randomUUID())
+                  .with(SecurityFixtures.authenticatedJwt()))
           .andExpect(status().isOk());
 
       verify(userExtensionService).deprovision(any());
@@ -390,7 +348,9 @@ class UserControllerTest extends AbstractControllerTest {
     @DisplayName("should return 200 when user exists")
     void shouldReturn200WhenUserExists() throws Exception {
       mockMvc
-          .perform(post("/users/{id}/restore", UUID.randomUUID()).with(authenticatedJwt()))
+          .perform(
+              post("/users/{id}/restore", UUID.randomUUID())
+                  .with(SecurityFixtures.authenticatedJwt()))
           .andExpect(status().isOk());
 
       verify(userExtensionService).restore(any());

--- a/src/test/java/com/ebikes/iam/services/users/UserExtensionServiceTest.java
+++ b/src/test/java/com/ebikes/iam/services/users/UserExtensionServiceTest.java
@@ -3,7 +3,6 @@ package com.ebikes.iam.services.users;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -34,6 +33,7 @@ import com.ebikes.iam.database.repositories.UserExtensionRepository;
 import com.ebikes.iam.dtos.requests.filters.UserExtensionFilter;
 import com.ebikes.iam.dtos.requests.users.CreateUserRequest;
 import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
+import com.ebikes.iam.dtos.responses.memberships.MembershipResponse;
 import com.ebikes.iam.dtos.responses.users.UserExtensionDetailResponse;
 import com.ebikes.iam.dtos.responses.users.UserExtensionSummaryResponse;
 import com.ebikes.iam.dtos.responses.users.UserProfileResponse;
@@ -41,8 +41,8 @@ import com.ebikes.iam.enums.UserRole;
 import com.ebikes.iam.enums.UserStatus;
 import com.ebikes.iam.exceptions.ResourceNotFoundException;
 import com.ebikes.iam.exceptions.ValidationException;
+import com.ebikes.iam.mappers.MembershipEnricher;
 import com.ebikes.iam.mappers.UserExtensionMapper;
-import com.ebikes.iam.services.notifications.NotificationService;
 import com.ebikes.iam.support.audit.AuditTemplate;
 import com.ebikes.iam.support.audit.ThrowingRunnable;
 import com.ebikes.iam.support.audit.ThrowingSupplier;
@@ -59,7 +59,7 @@ class UserExtensionServiceTest {
 
   @Mock private AuditTemplate auditTemplate;
   @Mock private KeycloakUserAdapter keycloakUserAdapter;
-  @Mock private NotificationService notificationService;
+  @Mock private MembershipEnricher membershipEnricher;
   @Mock private UserExtensionMapper mapper;
   @Mock private UserExtensionRepository repository;
 
@@ -67,7 +67,9 @@ class UserExtensionServiceTest {
 
   @BeforeEach
   void setUp() {
-    service = new UserExtensionService(auditTemplate, keycloakUserAdapter, mapper, repository);
+    service =
+        new UserExtensionService(
+            auditTemplate, keycloakUserAdapter, membershipEnricher, mapper, repository);
 
     ExecutionContext.set(
         UUID.randomUUID().toString(),
@@ -364,9 +366,11 @@ class UserExtensionServiceTest {
     @Test
     @DisplayName("should return profile response for matching org membership")
     void shouldReturnProfileForMatchingOrgMembership() {
+      UUID membershipId = UUID.randomUUID();
       UserExtension user = UserExtensionFixtures.active(ORGANIZATION_ID);
       Membership membership =
           Membership.builder()
+              .id(membershipId)
               .userExtension(user)
               .keycloakUserId(user.getKeycloakUserId())
               .organizationId(ORGANIZATION_ID)
@@ -374,6 +378,19 @@ class UserExtensionServiceTest {
               .isPrimary(true)
               .build();
       user.getMemberships().add(membership);
+
+      MembershipResponse activeMembershipResponse =
+          new MembershipResponse(
+              membershipId,
+              null,
+              null,
+              true,
+              "/" + ORGANIZATION_ID,
+              user.getKeycloakUserId(),
+              ORGANIZATION_ID,
+              null,
+              Set.of(),
+              null);
 
       UserProfileResponse response =
           new UserProfileResponse(
@@ -392,7 +409,10 @@ class UserExtensionServiceTest {
               user.getUsername());
 
       when(repository.findByKeycloakUserIdWithMemberships(any())).thenReturn(Optional.of(user));
-      when(mapper.toProfileResponse(eq(user), eq(membership), any())).thenReturn(response);
+      when(membershipEnricher.enrich(any())).thenReturn(List.of(activeMembershipResponse));
+      when(mapper.toProfileResponse(
+              user, activeMembershipResponse, List.of(activeMembershipResponse)))
+          .thenReturn(response);
 
       assertThat(service.me()).isEqualTo(response);
     }

--- a/src/test/java/com/ebikes/iam/support/fixtures/UserRequestFixtures.java
+++ b/src/test/java/com/ebikes/iam/support/fixtures/UserRequestFixtures.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import com.ebikes.iam.dtos.requests.users.CreateUserRequest;
 import com.ebikes.iam.dtos.requests.users.SignupRequest;
+import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
 import com.ebikes.iam.enums.UserRole;
 
 import net.datafaker.Faker;
@@ -23,6 +24,34 @@ public final class UserRequestFixtures {
     return baseCreateUser(organizationId, Set.of(UserRole.CUSTOMER));
   }
 
+  public static CreateUserRequest createUserWithBlankEmail() {
+    return new CreateUserRequest(
+        null,
+        "KE",
+        "",
+        FAKER.name().firstName(),
+        true,
+        FAKER.name().lastName(),
+        UUID.randomUUID().toString(),
+        "+254" + FAKER.number().digits(9),
+        Set.of(UserRole.CUSTOMER),
+        FAKER.credentials().username());
+  }
+
+  public static CreateUserRequest createUserWithEmptyRoles() {
+    return new CreateUserRequest(
+        null,
+        "KE",
+        FAKER.internet().emailAddress(),
+        FAKER.name().firstName(),
+        true,
+        FAKER.name().lastName(),
+        UUID.randomUUID().toString(),
+        "+254" + FAKER.number().digits(9),
+        Set.of(),
+        FAKER.credentials().username());
+  }
+
   public static SignupRequest signup() {
     return new SignupRequest(
         "KE",
@@ -31,6 +60,38 @@ public final class UserRequestFixtures {
         FAKER.name().lastName(),
         "+254" + FAKER.number().digits(9),
         FAKER.credentials().username());
+  }
+
+  public static SignupRequest signupWithBlankEmail() {
+    return new SignupRequest(
+        "KE",
+        "",
+        FAKER.name().firstName(),
+        FAKER.name().lastName(),
+        "+254" + FAKER.number().digits(9),
+        FAKER.credentials().username());
+  }
+
+  public static SignupRequest signupWithBlankPhoneNumber() {
+    return new SignupRequest(
+        "KE",
+        FAKER.internet().emailAddress(),
+        FAKER.name().firstName(),
+        FAKER.name().lastName(),
+        "",
+        FAKER.credentials().username());
+  }
+
+  public static UpdateUserExtensionRequest updateUser() {
+    return new UpdateUserExtensionRequest(
+        FAKER.internet().emailAddress(),
+        false,
+        FAKER.name().firstName(),
+        FAKER.name().lastName(),
+        null,
+        "+254" + FAKER.number().digits(9),
+        false,
+        null);
   }
 
   private static CreateUserRequest baseCreateUser(String organizationId, Set<UserRole> roles) {

--- a/src/test/java/com/ebikes/iam/support/infrastructure/AbstractIntegrationTest.java
+++ b/src/test/java/com/ebikes/iam/support/infrastructure/AbstractIntegrationTest.java
@@ -16,7 +16,7 @@ import com.ebikes.iam.support.fixtures.SecurityFixtures;
 @ActiveProfiles({"test", "integration-test"})
 @AutoConfigureMockMvc
 @ExtendWith(WithExecutionContext.class)
-@Import({IntegrationContainersConfig.class, MockKeycloakConfig.class})
+@Import({IntegrationContainersConfig.class, MockKeycloakConfig.class, MockOAuth2ClientConfig.class})
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Tag("integration")
 public abstract class AbstractIntegrationTest {

--- a/src/test/java/com/ebikes/iam/support/infrastructure/MockOAuth2ClientConfig.java
+++ b/src/test/java/com/ebikes/iam/support/infrastructure/MockOAuth2ClientConfig.java
@@ -1,0 +1,46 @@
+package com.ebikes.iam.support.infrastructure;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class MockOAuth2ClientConfig {
+
+  @Bean
+  @Primary
+  public ClientRegistrationRepository clientRegistrationRepository() {
+    ClientRegistration registration =
+        ClientRegistration.withRegistrationId("organizations")
+            .clientId("test-client")
+            .clientSecret("test-secret")
+            .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+            .tokenUri("http://localhost:0/realms/ebikes/protocol/openid-connect/token")
+            .build();
+    return new InMemoryClientRegistrationRepository(registration);
+  }
+
+  @Bean
+  @Primary
+  public OAuth2AuthorizedClientService authorizedClientService(
+      ClientRegistrationRepository clientRegistrationRepository) {
+    return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+  }
+
+  @Bean
+  @Primary
+  public OAuth2AuthorizedClientManager authorizedClientManager(
+      ClientRegistrationRepository clientRegistrationRepository,
+      OAuth2AuthorizedClientService authorizedClientService) {
+    return new AuthorizedClientServiceOAuth2AuthorizedClientManager(
+        clientRegistrationRepository, authorizedClientService);
+  }
+}

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -1,7 +1,4 @@
 spring:
-  autoconfigure:
-    exclude: []
-
   cloud:
     stream:
       default-binder: rabbit

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -12,6 +12,8 @@ spring:
       - org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
       - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+      - org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientAutoConfiguration
+      - org.springframework.boot.security.oauth2.client.autoconfigure.servlet.OAuth2ClientWebSecurityAutoConfiguration
 
   application:
     name: ebikes-iam
@@ -88,6 +90,17 @@ spring:
 
   security:
     oauth2:
+      client:
+        registration:
+          organizations:
+            provider: keycloak
+            client-id: test-client
+            client-secret: test-secret
+            authorization-grant-type: client_credentials
+            client-authentication-method: client_secret_basic
+        provider:
+            keycloak:
+                issuer-uri: http://localhost:0/realms/ebikes
       resourceserver:
         jwt:
           # Placeholder values — never resolved directly from this file.
@@ -116,11 +129,11 @@ clients:
     base-url: http://localhost
     verification:
       account-activation:
-        path: /activate
+        path: /verify
       email:
         path: /verify
       password-reset:
-        path: /reset-password
+        path: /verify
 
 contact:
   expiry-cron: 0 0 2 * * *
@@ -141,6 +154,22 @@ keycloak:
   # @DynamicPropertySource.
   url: http://localhost:0
   web-client-id: test-web-client
+
+logging:
+  level:
+    root: INFO
+    com.ebikes.iam: DEBUG
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
+
+management:
+  endpoint:
+    health:
+      show-details: never
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
 
 notifications:
   enabled: false
@@ -180,6 +209,7 @@ seed:
 services:
   organizations:
     base-url: http://localhost:0
+    client-registration-id: organizations
 
 token:
   account-activation:


### PR DESCRIPTION
## Purpose

Replaces the IAM service's unauthenticated `RestClient` construction for inter-service calls with Spring OAuth2 `client_credentials`, introduces `MembershipEnricher` into the user profile response flow so memberships carry resolved organization and branch names, adds a `SYSTEM_ADMIN` bypass in `AuthorizationService`, and cleans up test inconsistencies uncovered during these changes.

## List of Changes

**OAuth2 client credentials for organization service**
- Added `spring-boot-starter-oauth2-client` dependency.
- Replaced inline `RestClient.Builder` construction in `OrganizationServiceAdapter` with `@Qualifier("organizationServiceRestClient")` injection; added `clientRegistrationId` to `OrganizationServiceProperties`.
- Migrated `findOrganizationsByIds` and `findBranchesByIds` from `POST` with a request body to `GET` with `?ids=` query parameters to align with the organization service API contract.
- Unified Keycloak client credential env vars from `KEYCLOAK_CLIENT_ID/SECRET` to `IAM_CLIENT_ID/SECRET` in `application.yaml`.
- Removed redundant `ContextFilter` `@Bean` declaration from `SecurityConfiguration`.
- Added SpotBugs suppression for `EI_EXPOSE_REP2` false positive on injected `RestClient`.
- Excluded `OAuth2ClientAutoConfiguration` and `OAuth2ClientWebSecurityAutoConfiguration` from the unit test profile; added `MockOAuth2ClientConfig` to `AbstractIntegrationTest`.
- Removed stale `spring.autoconfigure.exclude: []` from `application-integration-test.yml`.
- Updated `OrganizationServiceAdapterTest` to mock `GET` + `Function<UriBuilder, URI>` instead of `POST` + body.

**Membership enrichment in profile response**
- Removed `MembershipMapper` from `UserExtensionMapper`'s `uses` clause; mapper methods now accept `MembershipResponse` DTOs directly.
- Updated `UserExtensionService.me()` to call `MembershipEnricher.enrich()`, match the active membership by ID against the enriched list, and pass enriched `MembershipResponse` objects into the profile mapper.
- Removed unused `@Serial serialVersionUID` field from `UserExtension`.
- Updated `UserExtensionServiceTest` to mock `MembershipEnricher` and align the `toProfileResponse` stub with the new `MembershipResponse`-based signature.

**System admin authorization bypass**
- Added a `SYSTEM_ADMIN` role early-return guard in `AuthorizationService`, sitting after the existing machine-client bypass.

**Test fixture and controller test cleanup**
- Added `createUserWithBlankEmail()`, `createUserWithEmptyRoles()`, `signupWithBlankEmail()`, `signupWithBlankPhoneNumber()`, and `updateUser()` factory methods to `UserRequestFixtures`.
- Replaced all hardcoded JSON request bodies in `UserControllerTest` with serialized fixture objects.
- Standardised all `authenticatedJwt()` calls to `SecurityFixtures.authenticatedJwt()`.

## Linked Issues

N/A

## How to Test

1. Ensure `IAM_CLIENT_ID`, `IAM_CLIENT_SECRET`, and `SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI` are set in your environment (replacing the former `KEYCLOAK_CLIENT_ID` / `KEYCLOAK_CLIENT_SECRET` variables — update local `.env` files and deployment configs accordingly).
2. Start the stack via `iam.sh`.
3. Authenticate as a regular user and call `GET /users/me` — verify the response includes resolved organization and branch names on each membership entry.
4. Authenticate as a system admin and invoke an endpoint that triggers authorization checks (e.g. `POST /users`) — verify it succeeds regardless of active branch context.
5. Trigger any flow that calls the organization service and confirm requests succeed with a valid bearer token attached.
6. Run the full test suite — `mvn verify`.

## Additional Information
- N/A