### PR TITLE
chore(iam): standardize cache key prefixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,9 @@ repos:
 
   - repo: local
     hooks:
-      - id: spotless-check
-        name: Spotless check
-        entry: ./mvnw -q spotless:check
+      - id: spotless-apply
+        name: Spotless apply
+        entry: ./mvnw -q spotless:apply
         language: system
         pass_filenames: false
         files: ^(pom\.xml|src/main/java/.*\.java|src/test/java/.*\.java|.*\.md|\.gitignore|\.gitattributes)$

--- a/src/main/java/com/ebikes/iam/services/cache/OrganizationCacheService.java
+++ b/src/main/java/com/ebikes/iam/services/cache/OrganizationCacheService.java
@@ -22,8 +22,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class OrganizationCacheService {
 
-  private static final String BRANCH_KEY_PREFIX = "organizations:branch:";
-  private static final String ORGANIZATIONS_KEY_PREFIX = "organizations:organization:";
+  private static final String BRANCH_KEY_PREFIX = "iam:branch:";
+  private static final String ORGANIZATIONS_KEY_PREFIX = "iam:organization:";
 
   private final CacheProperties cacheProperties;
   private final OrganizationServiceAdapter adapter;

--- a/src/test/java/com/ebikes/iam/services/cache/OrganizationCacheServiceTest.java
+++ b/src/test/java/com/ebikes/iam/services/cache/OrganizationCacheServiceTest.java
@@ -37,10 +37,8 @@ class OrganizationCacheServiceTest {
   private static final String BRANCH_NAME = "Test Branch";
   private static final int TTL_MINUTES = 10;
 
-  private static final String ORGANIZATION_CACHE_KEY =
-      "organizations:organization:" + ORGANIZATION_ID;
-  private static final String BRANCH_CACHE_KEY =
-      "organizations:branch:" + ORGANIZATION_ID + ":" + BRANCH_ID;
+  private static final String ORGANIZATION_CACHE_KEY = "iam:organization:" + ORGANIZATION_ID;
+  private static final String BRANCH_CACHE_KEY = "iam:branch:" + ORGANIZATION_ID + ":" + BRANCH_ID;
 
   @Mock private CacheProperties cacheProperties;
   @Mock private OrganizationServiceAdapter adapter;
@@ -115,9 +113,8 @@ class OrganizationCacheServiceTest {
       String missOrgId = "org-miss";
       String missOrgName = "Miss Org";
 
-      when(valueOperations.get("organizations:organization:" + cachedOrgId))
-          .thenReturn(cachedOrgName);
-      when(valueOperations.get("organizations:organization:" + missOrgId)).thenReturn(null);
+      when(valueOperations.get("iam:organization:" + cachedOrgId)).thenReturn(cachedOrgName);
+      when(valueOperations.get("iam:organization:" + missOrgId)).thenReturn(null);
       when(adapter.findOrganizationsByIds(Set.of(missOrgId)))
           .thenReturn(List.of(new Organization(missOrgId, missOrgName)));
       when(cacheProperties.getTtlMinutes()).thenReturn(TTL_MINUTES);
@@ -175,9 +172,9 @@ class OrganizationCacheServiceTest {
       String missBranchId = "branch-miss";
       String missBranchName = "Miss Branch";
 
-      when(valueOperations.get("organizations:branch:" + ORGANIZATION_ID + ":" + cachedBranchId))
+      when(valueOperations.get("iam:branch:" + ORGANIZATION_ID + ":" + cachedBranchId))
           .thenReturn(cachedBranchName);
-      when(valueOperations.get("organizations:branch:" + ORGANIZATION_ID + ":" + missBranchId))
+      when(valueOperations.get("iam:branch:" + ORGANIZATION_ID + ":" + missBranchId))
           .thenReturn(null);
       when(adapter.findBranchesByIds(ORGANIZATION_ID, Set.of(missBranchId)))
           .thenReturn(List.of(new Branch(missBranchId, missBranchName)));


### PR DESCRIPTION
## Purpose

This pull request improves developer workflow and standardizes IAM cache key names.

It updates the local pre-commit hook to run `spotless:apply` instead of `spotless:check` so formatting issues are fixed automatically before commit. It also renames organization and branch Redis cache key prefixes from generic `organizations:*` keys to IAM-scoped `iam:*` keys to avoid ambiguous naming and better reflect service ownership.

## List of Changes

* Updated the local pre-commit hook from `spotless-check` to `spotless-apply`.
* Changed the hook entry from `./mvnw -q spotless:check` to `./mvnw -q spotless:apply`.
* Renamed Redis organization cache keys from `organizations:organization:*` to `iam:organization:*`.
* Renamed Redis branch cache keys from `organizations:branch:*` to `iam:branch:*`.
* Updated `OrganizationCacheServiceTest` constants and mocked Redis key lookups to match the new cache key prefixes.

## Linked Issues

* N/A

## How to Test

1. Run the pre-commit hook against a file with formatting issues and confirm it applies formatting automatically instead of failing on style violations.
2. Run the `OrganizationCacheServiceTest` test class and confirm all cache-related tests pass.
3. Verify organization cache entries are written and read using keys in the format `iam:organization:{organizationId}`.
4. Verify branch cache entries are written and read using keys in the format `iam:branch:{organizationId}:{branchId}`.

## Additional Information

This change does not introduce new API behavior or database migrations.

Reviewers should note that the Redis cache key namespace has changed. Existing cached entries using the old `organizations:*` prefixes will no longer be read by this service after deployment.
