### PR TITLE
feat(users): expose bulk user reference lookup endpoint for inter-service queries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:21-jre-alpine@sha256:9f1de3e01a3c43e2f158abf408ec761813da639961bde93427c1ea42a619a09b
+# eclipse-temurin 21-jre-alpine as of 2026-04-09
+FROM eclipse-temurin@sha256:6ad8ed080d9be96b61438ec3ce99388e294af216ed57356000c06070e85c5d5d
 
 RUN apk add --no-cache shadow tzdata
 
@@ -9,14 +10,14 @@ RUN addgroup -S appgroup && \
     mkdir -p /app/logs && \
     chown -R appuser:appgroup /app
 
-COPY --chown=appuser:appgroup dependencies/ ./
-COPY --chown=appuser:appgroup spring-boot-loader/ ./
-COPY --chown=appuser:appgroup snapshot-dependencies*/ ./
-COPY --chown=appuser:appgroup application/ ./
+COPY --chown=appuser:appgroup --chmod=550 dependencies/ ./
+COPY --chown=appuser:appgroup --chmod=550 spring-boot-loader/ ./
+COPY --chown=appuser:appgroup --chmod=550 snapshot-dependencies*/ ./
+COPY --chown=appuser:appgroup --chmod=550 application/ ./
 
 ENV TZ=Africa/Nairobi
 
-EXPOSE 8091
+EXPOSE 8085
 
 USER appuser
 
@@ -27,9 +28,9 @@ ARG VERSION
 ARG BUILD_DATE
 ARG VCS_REF
 
-LABEL org.opencontainers.image.title="eBikes Africa notifications service"
+LABEL org.opencontainers.image.title="Ebikes Africa IAM service"
 LABEL org.opencontainers.image.description=""
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.created="${BUILD_DATE}"
-LABEL org.opencontainers.image.source="https://github.com/EbikesAfrica254/notifications"
+LABEL org.opencontainers.image.source="https://github.com/EbikesAfrica254/iam"
 LABEL org.opencontainers.image.revision="${VCS_REF}"

--- a/src/main/java/com/ebikes/iam/controllers/UserController.java
+++ b/src/main/java/com/ebikes/iam/controllers/UserController.java
@@ -1,5 +1,6 @@
 package com.ebikes.iam.controllers;
 
+import java.util.List;
 import java.util.UUID;
 
 import jakarta.validation.Valid;
@@ -25,6 +26,7 @@ import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
 import com.ebikes.iam.dtos.responses.api.PaginatedResponse;
 import com.ebikes.iam.dtos.responses.api.SuccessResponse;
 import com.ebikes.iam.dtos.responses.users.UserExtensionDetailResponse;
+import com.ebikes.iam.dtos.responses.users.UserExtensionReference;
 import com.ebikes.iam.dtos.responses.users.UserExtensionSummaryResponse;
 import com.ebikes.iam.dtos.responses.users.UserProfileResponse;
 import com.ebikes.iam.enums.UserStatus;
@@ -84,6 +86,14 @@ public class UserController {
       @ModelAttribute UserExtensionFilter filter) {
     Page<UserExtensionSummaryResponse> page = userExtensionService.search(filter);
     return ResponseEntity.ok(PaginatedResponse.from("Users retrieved successfully.", page));
+  }
+
+  @GetMapping("/reference")
+  public ResponseEntity<SuccessResponse<List<UserExtensionReference>>> findReferences(
+      @RequestParam List<String> ids) {
+    List<UserExtensionReference> references =
+        userExtensionService.findByReferenceKeycloakUserIds(ids);
+    return ResponseEntity.ok(SuccessResponse.of(references));
   }
 
   @PostMapping("/signup")

--- a/src/main/java/com/ebikes/iam/database/repositories/UserExtensionRepository.java
+++ b/src/main/java/com/ebikes/iam/database/repositories/UserExtensionRepository.java
@@ -1,5 +1,6 @@
 package com.ebikes.iam.database.repositories;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.ebikes.iam.database.entities.UserExtension;
+import com.ebikes.iam.dtos.responses.users.UserExtensionReference;
 
 @Repository
 public interface UserExtensionRepository
@@ -19,6 +21,8 @@ public interface UserExtensionRepository
   Optional<UserExtension> findByEmail(String email);
 
   Optional<UserExtension> findByKeycloakUserId(String keycloakUserId);
+
+  List<UserExtensionReference> findByKeycloakUserIdIn(List<String> keycloakUserIds);
 
   @EntityGraph(attributePaths = {"memberships"})
   @Query("SELECT ue FROM UserExtension ue WHERE ue.keycloakUserId = :keycloakUserId")

--- a/src/main/java/com/ebikes/iam/dtos/responses/users/UserExtensionReference.java
+++ b/src/main/java/com/ebikes/iam/dtos/responses/users/UserExtensionReference.java
@@ -1,0 +1,6 @@
+package com.ebikes.iam.dtos.responses.users;
+
+import java.util.UUID;
+
+public record UserExtensionReference(
+    UUID id, String keycloakUserId, String firstName, String lastName, String username) {}

--- a/src/main/java/com/ebikes/iam/mappers/UserExtensionMapper.java
+++ b/src/main/java/com/ebikes/iam/mappers/UserExtensionMapper.java
@@ -10,6 +10,7 @@ import org.mapstruct.ReportingPolicy;
 import com.ebikes.iam.database.entities.UserExtension;
 import com.ebikes.iam.dtos.responses.memberships.MembershipResponse;
 import com.ebikes.iam.dtos.responses.users.UserExtensionDetailResponse;
+import com.ebikes.iam.dtos.responses.users.UserExtensionReference;
 import com.ebikes.iam.dtos.responses.users.UserExtensionSummaryResponse;
 import com.ebikes.iam.dtos.responses.users.UserProfileResponse;
 
@@ -21,8 +22,6 @@ public interface UserExtensionMapper {
 
   UserExtensionDetailResponse toDetailResponse(UserExtension userExtension);
 
-  UserExtensionSummaryResponse toSummaryResponse(UserExtension userExtension);
-
   @Mapping(target = "activeMembership", source = "activeMembership")
   @Mapping(target = "createdAt", source = "userExtension.createdAt")
   @Mapping(target = "id", source = "userExtension.id")
@@ -31,4 +30,8 @@ public interface UserExtensionMapper {
       UserExtension userExtension,
       MembershipResponse activeMembership,
       List<MembershipResponse> memberships);
+
+  UserExtensionReference toReference(UserExtension userExtension);
+
+  UserExtensionSummaryResponse toSummaryResponse(UserExtension userExtension);
 }

--- a/src/main/java/com/ebikes/iam/services/users/UserExtensionService.java
+++ b/src/main/java/com/ebikes/iam/services/users/UserExtensionService.java
@@ -25,6 +25,7 @@ import com.ebikes.iam.dtos.requests.users.CreateUserRequest;
 import com.ebikes.iam.dtos.requests.users.UpdateUserExtensionRequest;
 import com.ebikes.iam.dtos.responses.memberships.MembershipResponse;
 import com.ebikes.iam.dtos.responses.users.UserExtensionDetailResponse;
+import com.ebikes.iam.dtos.responses.users.UserExtensionReference;
 import com.ebikes.iam.dtos.responses.users.UserExtensionSummaryResponse;
 import com.ebikes.iam.dtos.responses.users.UserProfileResponse;
 import com.ebikes.iam.enums.ResponseCode;
@@ -171,6 +172,11 @@ public class UserExtensionService {
   }
 
   @Transactional(readOnly = true)
+  public List<UserExtensionReference> findByReferenceKeycloakUserIds(List<String> keycloakUserIds) {
+    return repository.findByKeycloakUserIdIn(keycloakUserIds);
+  }
+
+  @Transactional(readOnly = true)
   public Optional<UserExtension> findUserExtensionByEmail(String email) {
     return repository.findByEmail(email);
   }
@@ -191,6 +197,7 @@ public class UserExtensionService {
     return repository.findByPhoneNumber(phoneNumber);
   }
 
+  @Transactional(readOnly = true)
   public UserProfileResponse me() {
     if (!(ExecutionContext.get() instanceof ExecutionContext.UserContext ctx)) {
       throw new IllegalStateException("me() called outside of user context");


### PR DESCRIPTION
## Purpose
Exposes a new bulk user reference endpoint (`GET /users/reference`) so that downstream services — specifically the notifications service — can resolve user display names by Keycloak user ID without coupling to the full user detail response.

**List of Changes**
- Added `UserExtensionReference` projection DTO carrying the fields required by downstream consumers.
- Added `findByKeycloakUserIdIn` to `UserExtensionRepository` using Spring Data's derived query mechanism, projecting directly to `UserExtensionReference`.
- Added `findByReferenceKeycloakUserIds` to `UserExtensionService` as a read-only transactional method delegating to the repository.
- Added `toReference` mapping method to `UserExtensionMapper`.
- Added `GET /users/reference?ids=...` endpoint to `UserController` returning a `SuccessResponse<List<UserExtensionReference>>`.
- Added missing `@Transactional(readOnly = true)` to `UserExtensionService.me()`.
- Pinned the Docker base image to a digest-locked `eclipse-temurin` 21-JRE Alpine image; restricted copied file permissions to `550`; updated exposed port to `8085` and corrected image labels to reflect the IAM service.

## Linked Issues
- N/A

**How to Test**
1. Start the IAM service with `mvn spring-boot:run`.
2. Obtain a valid access token via Keycloak.
3. Send a `GET` request to `localhost:8085/ebikes-iam/users/reference?ids=<keycloakUserId1>,<keycloakUserId2>`.
4. Confirm the response body is a `SuccessResponse` whose `data` array contains one entry per matched user with the expected reference fields.
5. Send a request with an ID that does not exist and confirm the response returns an empty list rather than an error.
6. Run `mvn verify` and confirm all tests pass.

**Additional Information**
- The endpoint is intentionally unauthenticated at the path level if called service-to-service via client credentials — confirm the security filter chain permits the `/users/reference` path for the appropriate client role.
- The Docker port change from `8091` to `8085` must be reflected in any `docker-compose` or infrastructure configuration that references the IAM service container.